### PR TITLE
Rename lisk-js to lisk-elements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@
  *
  */
 pipeline {
-	agent { node { label 'lisk-js' } }
+	agent { node { label 'lisk-elements' } }
 	stages {
 		stage('Install dependencies') {
 			steps {
@@ -58,14 +58,14 @@ pipeline {
 	post {
 		success {
 			deleteDir()
-			githubNotify context: 'continuous-integration/jenkins/lisk-js', description: 'The build passed.', status: 'SUCCESS'
+			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build passed.', status: 'SUCCESS'
 		}
 		failure {
 			archiveArtifacts allowEmptyArchive: true, artifacts: 'cypress/screenshots/'
-			githubNotify context: 'continuous-integration/jenkins/lisk-js', description: 'The build failed.', status: 'FAILURE'
+			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build failed.', status: 'FAILURE'
 		}
 		aborted {
-			githubNotify context: 'continuous-integration/jenkins/lisk-js', description: 'The build was aborted.', status: 'ERROR'
+			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build was aborted.', status: 'ERROR'
 		}
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,5 +1,5 @@
 pipeline {
-       agent { node { label 'lisk-js' } }
+       agent { node { label 'lisk-elements' } }
        stages {
                stage('Cache dependencies') {
                        steps {

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# <a href="http://liskhq.github.io/lisk-js/">Lisk-JS</a>
+# <a href="http://liskhq.github.io/lisk-elements/">Lisk Elements</a>
 
-Lisk JS is a JavaScript library for [Lisk - the cryptocurrency and blockchain application platform](https://github.com/LiskHQ/lisk). It allows developers to create offline transactions and broadcast them onto the network. It also allows developers to interact with the core Lisk API, for retrieval of collections and single records of data located on the Lisk blockchain. Its main benefit is that it does not require a locally installed Lisk node, and instead utilizes the existing nodes on the network. It can be used from the client as a [browserify](http://browserify.org/) compiled module, or on the server as a standard Node.js module.
+Lisk Elements is a JavaScript library for [Lisk - the cryptocurrency and blockchain application platform](https://github.com/LiskHQ/lisk). It allows developers to create offline transactions and broadcast them onto the network. It also allows developers to interact with the core Lisk API, for retrieval of collections and single records of data located on the Lisk blockchain. Its main benefit is that it does not require a locally installed Lisk node, and instead utilizes the existing nodes on the network. It can be used from the client as a [browserify](http://browserify.org/) compiled module, or on the server as a standard Node.js module.
 
-[![Build Status](https://jenkins.lisk.io/buildStatus/icon?job=lisk-js/development)](https://jenkins.lisk.io/job/lisk-js/job/development/)
-[![Coverage Status](https://coveralls.io/repos/github/LiskHQ/lisk-js/badge.svg?branch=development)](https://coveralls.io/github/LiskHQ/lisk-js?branch=development)
+[![Build Status](https://jenkins.lisk.io/buildStatus/icon?job=lisk-elements/development)](https://jenkins.lisk.io/job/lisk-elements/job/development/)
+[![Coverage Status](https://coveralls.io/repos/github/LiskHQ/lisk-elements/badge.svg?branch=development)](https://coveralls.io/github/LiskHQ/lisk-elements?branch=development)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 [![GitHub release](https://img.shields.io/badge/version-0.4.5-blue.svg)](#)
 
 ## Browser
 
 ```html
-<script src="./lisk-js.js"></script>
+<script src="./lisk-elements.js"></script>
 <script>
 	lisk.api().searchDelegateByUsername('oliver', function (response) {
 		console.log(response);
@@ -20,26 +20,26 @@ Lisk JS is a JavaScript library for [Lisk - the cryptocurrency and blockchain ap
 
 ## CDN
 
-https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.js<br/>
+https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.js<br/>
 ```html
-<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.js"></script>
+<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.js"></script>
 ```
 Or minified:
-https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.min.js<br/>
+https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.min.js<br/>
 ```html
-<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.min.js"></script>
+<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.min.js"></script>
 ```
 
 ## Server
 
 ## Install
 ```
-$ npm install lisk-js --save
+$ npm install lisk-elements --save
 ```
 
 To learn more about the API or to experiment with some data, please go to the github page:
 
-http://liskhq.github.io/lisk-js/
+http://liskhq.github.io/lisk-elements/
 
 ## Tests
 
@@ -51,7 +51,7 @@ Tests written using mocha + schedule.js.
 
 ## Documentation
 
-- [Install](https://docs.lisk.io/docs/lisk-js-installation)
+- [Install](https://docs.lisk.io/docs/lisk-elements-installation)
 - [API](https://docs.lisk.io/docs/api-functions)
 	- [Settings](https://docs.lisk.io/docs/api)
 	- [API Functions](https://docs.lisk.io/docs/api-functions)
@@ -80,11 +80,11 @@ This program is free software: you can redistribute it and/or modify it under th
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the [GNU General Public License](https://github.com/LiskHQ/lisk-js/tree/master/LICENSE) along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the [GNU General Public License](https://github.com/LiskHQ/lisk-elements/tree/master/LICENSE) along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ***
 
-This program also incorporates work previously released with lisk-js `0.2.3` (and earlier) versions under the [MIT License](https://opensource.org/licenses/MIT). To comply with the requirements of that license, the following permission notice, applicable to those parts of the code only, is included below:
+This program also incorporates work previously released with lisk-elements `0.2.3` (and earlier) versions under the [MIT License](https://opensource.org/licenses/MIT). To comply with the requirements of that license, the following permission notice, applicable to those parts of the code only, is included below:
 
 Copyright © 2016-2017 Lisk Foundation
 Copyright © 2015 Crypti

--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ Tests written using mocha + schedule.js.
 	- [Create Multisignature Account](https://docs.lisk.io/docs/transactions-1#section-createmultisignature)
 	- [Sign Multisignature Transaction](https://docs.lisk.io/docs/transactions-1#section-signtransaction)
 
-## Authors
+## Contributors
 
-- Boris Povod <boris@crypti.me>
-- Oliver Beddows <oliver@lightcurve.io>
-- Tobias Schwarz <tobias@lightcurve.io>
+https://github.com/LiskHQ/lisk-elements/graphs/contributors
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Tests written using mocha + schedule.js.
 
 ## License
 
-Copyright © 2016-2017 Lisk Foundation
+Copyright © 2016-2018 Lisk Foundation
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
@@ -84,7 +84,7 @@ You should have received a copy of the [GNU General Public License](https://gith
 
 ***
 
-This program also incorporates work previously released with lisk-elements `0.2.3` (and earlier) versions under the [MIT License](https://opensource.org/licenses/MIT). To comply with the requirements of that license, the following permission notice, applicable to those parts of the code only, is included below:
+This program also incorporates work previously released with lisk-js `v0.5.1` (and earlier) versions under the [MIT License](https://opensource.org/licenses/MIT). To comply with the requirements of that license, the following permission notice, applicable to those parts of the code only, is included below:
 
 Copyright © 2016-2017 Lisk Foundation
 Copyright © 2015 Crypti

--- a/bin/prestart.sh
+++ b/bin/prestart.sh
@@ -1,4 +1,4 @@
-read -r -p $'\e[96mDo you want to build LiskJS first? [y/N]\e[0m ' should_build
+read -r -p $'\e[96mDo you want to build Lisk Elements first? [y/N]\e[0m ' should_build
 if [[ $should_build =~ ^[Yy]$ ]]
 then
 	npm run build:node

--- a/bin/publish_browser.sh
+++ b/bin/publish_browser.sh
@@ -7,7 +7,7 @@ VERSION=$(node -p -e "require('./package.json').version")
 {
 	git checkout -b $BRANCHNAME_TEMP
 	mkdir dist-browser-temp
-	cp dist-browser/lisk-js.* $DIRNAME_TEMP && \
+	cp dist-browser/lisk-elements.* $DIRNAME_TEMP && \
 	cp dist-browser/README.md $DIRNAME_TEMP && \
 	git add dist-browser-temp && \
 	git commit -m "Publish browser version $VERSION" --no-verify && \

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,1 +1,1 @@
-node -i -e "global.LiskJS = require('./dist-node').default; console.log('\\x1b[34m', 'The global \`LiskJS\` was initialised', '\\x1b[0m')"
+node -i -e "global.LiskElements = require('./dist-node').default; console.log('\\x1b[34m', 'The global \`LiskElements\` was initialised', '\\x1b[0m')"

--- a/browsertest/run_tests.js
+++ b/browsertest/run_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/browsertest/setup.js
+++ b/browsertest/setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/cypress/integration/index.js
+++ b/cypress/integration/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/dist-browser/README.md
+++ b/dist-browser/README.md
@@ -1,6 +1,6 @@
-# lisk-js browser distribution
+# Lisk Elements browser distribution
 
-This branch contains the built lisk-js distribution files, ready for use in the browser. There is a
+This branch contains the built Lisk Elements distribution files, ready for use in the browser. There is a
 full build and a minified build (which is the one you want to use in most cases).
 
 ## Updating these files

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to Lisk-JS
+# Contributing to Lisk Elements
 
 First off, thanks for taking the time to contribute! :raised_hands:
 
-The following is a set of guidelines for contributing to Lisk-JS, which are hosted in the [LiskHQ Organization](https://github.com/LiskHQ) on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to Lisk Elements, which are hosted in the [LiskHQ Organization](https://github.com/LiskHQ) on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
 
@@ -21,7 +21,7 @@ The following is a set of guidelines for contributing to Lisk-JS, which are host
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Lisk-JS Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [info@lisk.io](mailto:info@lisk.io).
+This project and everyone participating in it is governed by the [Lisk Elements Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [info@lisk.io](mailto:info@lisk.io).
 
 ## Project License
 
@@ -63,7 +63,7 @@ In case you've never submitted a pull request (PR) via GitHub before, please rea
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for Lisk-JS. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for Lisk Elements. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
 
@@ -82,7 +82,7 @@ Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
 * **Use a clear and descriptive title** for the issue to identify the problem.
-* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started Lisk-JS, e.g. with Node.js or in the Browser (which one? which version?), or how you started Lisk-JS otherwise. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you have used an API model provide the configuration you have chosen and the functions you have executed. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started Lisk Elements, e.g. with Node.js or in the Browser (which one? which version?), or how you started Lisk Elements otherwise. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you have used an API model provide the configuration you have chosen and the functions you have executed. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
 * **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
 * **Explain which behavior you expected to see instead and why.**
@@ -91,13 +91,13 @@ Explain the problem and include additional details to help maintainers reproduce
 
 Provide more context by answering these questions:
 
-* **Did the problem start happening recently** (e.g. after updating to a new version of Lisk-JS, Lisk or any other repository) or was this always a problem?
-* If the problem started happening recently, **can you reproduce the problem in an older version of Lisk-JS?** What's the most recent version in which the problem doesn't happen? You can download older versions of Lisk-JS from [the releases page](https://github.com/LiskHQ/lisk-js/releases).
+* **Did the problem start happening recently** (e.g. after updating to a new version of Lisk Elements, Lisk or any other repository) or was this always a problem?
+* If the problem started happening recently, **can you reproduce the problem in an older version of Lisk Elements?** What's the most recent version in which the problem doesn't happen? You can download older versions of Lisk Elements from [the releases page](https://github.com/LiskHQ/lisk-elements/releases).
 * **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for Lisk-JS, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for Lisk Elements, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
  When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
@@ -109,9 +109,9 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 * **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 * **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
-* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk-JS which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-* **Explain why this enhancement would be useful** to most Lisk and Lisk-JS users.
-* **Specify which version of Lisk and Lisk-JS you're using.**
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk Elements which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+* **Explain why this enhancement would be useful** to most Lisk and Lisk Elements users.
+* **Specify which version of Lisk and Lisk Elements you're using.**
 * **Specify the name and version of the OS you're using.**
 
 ## Styleguides
@@ -141,7 +141,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 
 ### JavaScript Styleguide
 
-On Lisk-JS we are using [ESLint](https://eslint.org/).
+On Lisk Elements we are using [ESLint](https://eslint.org/).
 Our JavaScript style expands [Airbnb's](https://github.com/airbnb/javascript) style. You can get more details here: https://github.com/LiskHQ/eslint-config-lisk-base
 
 These contribution guidelines were inspired by and are based on Atom's contribution guidelines. They were modified for the purposes of this repository. https://github.com/atom/atom/blob/master/CONTRIBUTING.md - Copyright (c) 2011-2017 GitHub Inc. (MIT)

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Have you read Lisk-JS's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: [Lisk-JS Code of Conduct](CODE_OF_CONDUCT.md)
+Have you read Lisk Elements's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: [Lisk Elements Code of Conduct](CODE_OF_CONDUCT.md)
 
 ### Description
 
@@ -19,7 +19,7 @@ Have you read Lisk-JS's Code of Conduct? By filing an Issue, you are expected to
 ### Versions
 
 Please provide the version you are working with. Please include the OS and what version of the OS you're running.
-Also please tell us whether you are using Lisk-JS in a browser (which one? which version?) or in Node.js.
+Also please tell us whether you are using Lisk Elements in a browser (which one? which version?) or in Node.js.
 
 ### Additional Information
 

--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
     <title>Title</title>
 </head>
 <body>
-Open the console to get started with `lisk-js`.
+Open the console to get started with Lisk Elements`.
 <div id="output"></div>
 
-<script src="dist-browser/lisk-js.min.js"></script>
+<script src="dist-browser/lisk-elements.min.js"></script>
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "lisk-js",
+	"name": "lisk-elements",
 	"version": "0.4.5",
 	"description": "JavaScript library for sending Lisk transactions from the client or server",
 	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
@@ -11,13 +11,13 @@
 		"javascript",
 		"library"
 	],
-	"homepage": "https://github.com/LiskHQ/lisk-js#readme",
+	"homepage": "https://github.com/LiskHQ/lisk-elements#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/LiskHQ/lisk-js.git"
+		"url": "git+https://github.com/LiskHQ/lisk-elements.git"
 	},
 	"bugs": {
-		"url": "https://github.com/LiskHQ/lisk-js/issues"
+		"url": "https://github.com/LiskHQ/lisk-elements/issues"
 	},
 	"engines": {
 		"node": ">=6.3 <=9.5",
@@ -32,9 +32,9 @@
 		"lint:fix": "npm run lint -- --fix",
 		"babel": "babel src -d dist-node",
 		"babel:browsertest": "babel src -d ./browsertest/src && BABEL_ENV=browsertest babel test --ignore test/transactions/dapp.js -d ./browsertest/test",
-		"browserify": "browserify ./dist-node/index.js -o ./dist-browser/lisk-js.js -s lisk -t rewireify",
+		"browserify": "browserify ./dist-node/index.js -o ./dist-browser/lisk-elements.js -s lisk -t rewireify",
 		"browserify:browsertest": "browserify ./browsertest/test/*.js ./browsertest/test/**/*.js -o ./browsertest/browsertest.js -s lisk -t rewireify",
-		"uglify": "uglifyjs -nm -o ./dist-browser/lisk-js.min.js ./dist-browser/lisk-js.js",
+		"uglify": "uglifyjs -nm -o ./dist-browser/lisk-elements.min.js ./dist-browser/lisk-elements.js",
 		"uglify:browsertest": "uglifyjs -o ./browsertest/browsertest.min.js ./browsertest/browsertest.js",
 		"serve:browsertest": "http-server browsertest",
 		"test": "NODE_ENV=test nyc mocha test",
@@ -52,7 +52,7 @@
 		"postbuild:browsertest": "rm -r browsertest/src browsertest/test",
 		"prebuild:node": "rm -r dist-node/* || mkdir dist-node | echo",
 		"build:node": "npm run babel",
-		"prebuild:browser": "rm ./dist-browser/lisk-js.js ./dist-browser/lisk-js.min.js | echo",
+		"prebuild:browser": "rm ./dist-browser/lisk-elements.js ./dist-browser/lisk-elements.min.js | echo",
 		"build:browser": "npm run babel && npm run browserify && npm run uglify",
 		"prebuild": "npm run prebuild:node && npm run prebuild:browser",
 		"build": "npm run babel && npm run browserify && npm run uglify",

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -45,7 +45,8 @@ const commonHeaders = {
 const getUserAgent = (
 	{ name = '????', version = '????', engine = '????' } = {},
 ) => {
-	const liskJSInformation = 'LiskJS/1.0 (+https://github.com/LiskHQ/lisk-js)';
+	const liskElementsInformation =
+		'LiskElements/1.0 (+https://github.com/LiskHQ/lisk-elements)';
 	const locale =
 		process.env.LC_ALL ||
 		process.env.LC_MESSAGES ||
@@ -54,7 +55,7 @@ const getUserAgent = (
 	const systemInformation = `${os.platform()} ${os.release()}; ${os.arch()}${
 		locale ? `; ${locale}` : ''
 	}`;
-	return `${name}/${version} (${engine}) ${liskJSInformation} ${
+	return `${name}/${version} (${engine}) ${liskElementsInformation} ${
 		systemInformation
 	}`;
 };

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/api_method.js
+++ b/src/api_client/api_method.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/api_resource.js
+++ b/src/api_client/api_resource.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/constants.js
+++ b/src/api_client/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/index.js
+++ b/src/api_client/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/accounts.js
+++ b/src/api_client/resources/accounts.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/blocks.js
+++ b/src/api_client/resources/blocks.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/dapps.js
+++ b/src/api_client/resources/dapps.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/delegates.js
+++ b/src/api_client/resources/delegates.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/index.js
+++ b/src/api_client/resources/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/node.js
+++ b/src/api_client/resources/node.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/peers.js
+++ b/src/api_client/resources/peers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/signatures.js
+++ b/src/api_client/resources/signatures.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/transactions.js
+++ b/src/api_client/resources/transactions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/voters.js
+++ b/src/api_client/resources/voters.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/resources/votes.js
+++ b/src/api_client/resources/votes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/api_client/utils.js
+++ b/src/api_client/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/cryptography/encrypt.js
+++ b/src/cryptography/encrypt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/cryptography/hash.js
+++ b/src/cryptography/hash.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/cryptography/index.js
+++ b/src/cryptography/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/cryptography/keys.js
+++ b/src/cryptography/keys.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/cryptography/sign.js
+++ b/src/cryptography/sign.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/passphrase/index.js
+++ b/src/passphrase/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/passphrase/validation.js
+++ b/src/passphrase/validation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/0_transfer.js
+++ b/src/transactions/0_transfer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/1_register_second_passphrase.js
+++ b/src/transactions/1_register_second_passphrase.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/2_register_delegate.js
+++ b/src/transactions/2_register_delegate.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/3_cast_votes.js
+++ b/src/transactions/3_cast_votes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/4_register_multisignature_account.js
+++ b/src/transactions/4_register_multisignature_account.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/5_create_dapp.js
+++ b/src/transactions/5_create_dapp.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/constants.js
+++ b/src/transactions/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/create_signature_object.js
+++ b/src/transactions/create_signature_object.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/index.js
+++ b/src/transactions/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/format.js
+++ b/src/transactions/utils/format.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/get_address_and_public_key_from_recipient_data.js
+++ b/src/transactions/utils/get_address_and_public_key_from_recipient_data.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/get_transaction_bytes.js
+++ b/src/transactions/utils/get_transaction_bytes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/get_transaction_hash.js
+++ b/src/transactions/utils/get_transaction_hash.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/get_transaction_id.js
+++ b/src/transactions/utils/get_transaction_id.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/index.js
+++ b/src/transactions/utils/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/prepare_transaction.js
+++ b/src/transactions/utils/prepare_transaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/sign_and_verify.js
+++ b/src/transactions/utils/sign_and_verify.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/sign_raw_transaction.js
+++ b/src/transactions/utils/sign_raw_transaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/time.js
+++ b/src/transactions/utils/time.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/validation.js
+++ b/src/transactions/utils/validation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/src/transactions/utils/wrap_transaction_creator.js
+++ b/src/transactions/utils/wrap_transaction_creator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -45,7 +45,7 @@ describe('APIClient module', () => {
 	const platformInfo = `${os.platform()} ${os.release()}; ${os.arch()}${
 		locale ? `; ${locale}` : ''
 	}`;
-	const baseUserAgent = `LiskJS/1.0 (+https://github.com/LiskHQ/lisk-js) ${
+	const baseUserAgent = `LiskElements/1.0 (+https://github.com/LiskHQ/lisk-elements) ${
 		platformInfo
 	}`;
 	const defaultUserAgent = `????/???? (????) ${baseUserAgent}`;

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/api_method.js
+++ b/test/api_client/api_method.js
@@ -24,7 +24,7 @@ describe('API method module', () => {
 	const defaultHeaders = {
 		'Content-Type': 'application/json',
 		nethash: 'mainnetHash',
-		os: 'lisk-js-api',
+		os: 'lisk-elements-api',
 		version: '1.0.0',
 		minVersion: '>=0.5.0',
 		port: '443',

--- a/test/api_client/api_method.js
+++ b/test/api_client/api_method.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -25,7 +25,7 @@ describe('API resource module', () => {
 	const defaultHeaders = {
 		'Content-Type': 'application/json',
 		nethash: 'mainnetHash',
-		os: 'lisk-js-api',
+		os: 'lisk-elements-api',
 		version: '1.0.0',
 		minVersion: '>=0.5.0',
 		port: '443',

--- a/test/api_client/constants.js
+++ b/test/api_client/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/index.js
+++ b/test/api_client/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/accounts.js
+++ b/test/api_client/resources/accounts.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/blocks.js
+++ b/test/api_client/resources/blocks.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/dapps.js
+++ b/test/api_client/resources/dapps.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/delegates.js
+++ b/test/api_client/resources/delegates.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/node.js
+++ b/test/api_client/resources/node.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/peers.js
+++ b/test/api_client/resources/peers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/signatures.js
+++ b/test/api_client/resources/signatures.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/transactions.js
+++ b/test/api_client/resources/transactions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/voters.js
+++ b/test/api_client/resources/voters.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/resources/votes.js
+++ b/test/api_client/resources/votes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/api_client/utils.js
+++ b/test/api_client/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/cryptography/encrypt.js
+++ b/test/cryptography/encrypt.js
@@ -206,7 +206,7 @@ describe('encrypt', () => {
 					.and.be.hexString.and.have.length(32);
 			});
 
-			it('should output the current version of LiskJS', () => {
+			it('should output the current version of Lisk Elements', () => {
 				return expect(encryptedPassphrase)
 					.to.have.property('version')
 					.which.is.equal(ENCRYPTION_VERSION);

--- a/test/cryptography/encrypt.js
+++ b/test/cryptography/encrypt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/cryptography/hash.js
+++ b/test/cryptography/hash.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/cryptography/index.js
+++ b/test/cryptography/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/cryptography/keys.js
+++ b/test/cryptography/keys.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/cryptography/sign.js
+++ b/test/cryptography/sign.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/passphrase/index.js
+++ b/test/passphrase/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/passphrase/validation.js
+++ b/test/passphrase/validation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/0_transfer.js
+++ b/test/transactions/0_transfer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/1_register_second_passphrase.js
+++ b/test/transactions/1_register_second_passphrase.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/2_register_delegate.js
+++ b/test/transactions/2_register_delegate.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/3_cast_votes.js
+++ b/test/transactions/3_cast_votes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/4_register_multisignature_account.js
+++ b/test/transactions/4_register_multisignature_account.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/5_create_dapp.js
+++ b/test/transactions/5_create_dapp.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/constants.js
+++ b/test/transactions/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/create_signature_object.js
+++ b/test/transactions/create_signature_object.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/index.js
+++ b/test/transactions/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/format.js
+++ b/test/transactions/utils/format.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/get_address_and_public_key_from_recipient_data.js
+++ b/test/transactions/utils/get_address_and_public_key_from_recipient_data.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/get_transaction_bytes.js
+++ b/test/transactions/utils/get_transaction_bytes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/get_transaction_hash.js
+++ b/test/transactions/utils/get_transaction_hash.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/get_transaction_id.js
+++ b/test/transactions/utils/get_transaction_id.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/index.js
+++ b/test/transactions/utils/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/prepare_transaction.js
+++ b/test/transactions/utils/prepare_transaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/sign_and_verify.js
+++ b/test/transactions/utils/sign_and_verify.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -18,7 +18,7 @@ import {
 	multiSignTransaction,
 	verifyTransaction,
 } from 'transactions/utils';
-// The list of valid transactions was created with Lisk Elements v0.5.1
+// The list of valid transactions was created with lisk-js v0.5.1
 // using the below mentioned passphrases.
 import validTransactions from '../../../fixtures/transactions.json';
 // Require is used for stubbing

--- a/test/transactions/utils/sign_and_verify.js
+++ b/test/transactions/utils/sign_and_verify.js
@@ -18,7 +18,7 @@ import {
 	multiSignTransaction,
 	verifyTransaction,
 } from 'transactions/utils';
-// The list of valid transactions was created with lisk-js 0.5.1
+// The list of valid transactions was created with Lisk Elements v0.5.1
 // using the below mentioned passphrases.
 import validTransactions from '../../../fixtures/transactions.json';
 // Require is used for stubbing

--- a/test/transactions/utils/sign_raw_transaction.js
+++ b/test/transactions/utils/sign_raw_transaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/time.js
+++ b/test/transactions/utils/time.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/validation.js
+++ b/test/transactions/utils/validation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/test/transactions/utils/wrap_transaction_creator.js
+++ b/test/transactions/utils/wrap_transaction_creator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Lisk Foundation
+ * Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.


### PR DESCRIPTION
### What was the problem?

We still had the old name `lisk-js`.

### How did I fix it?

Renamed everything in the code base to `lisk-elements`

### How to test it?

Search for all combinations of `lisk-js` name

### Review checklist

* The PR is a partial solution to #567 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
