### PR TITLE
Remove reconnect max count - Closes #661

### DIFF
--- a/src/api_client/api_resource.js
+++ b/src/api_client/api_resource.js
@@ -14,7 +14,8 @@
  */
 
 import * as popsicle from 'popsicle';
-import { API_RECONNECT_MAX_RETRY_COUNT } from './constants';
+
+const API_RECONNECT_MAX_RETRY_COUNT = 3;
 
 export default class APIResource {
 	constructor(apiClient) {

--- a/src/api_client/constants.js
+++ b/src/api_client/constants.js
@@ -15,7 +15,6 @@
 export const GET = 'GET';
 export const POST = 'POST';
 export const PUT = 'PUT';
-export const API_RECONNECT_MAX_RETRY_COUNT = 3;
 
 export const BETANET_NODES = [
 	'http://94.237.42.109:5000',

--- a/test/api_client/constants.js
+++ b/test/api_client/constants.js
@@ -16,7 +16,6 @@ import {
 	GET,
 	POST,
 	PUT,
-	API_RECONNECT_MAX_RETRY_COUNT,
 	BETANET_NODES,
 	TESTNET_NODES,
 	MAINNET_NODES,
@@ -33,10 +32,6 @@ describe('api constants module', () => {
 
 	it('PUT should be a string', () => {
 		return expect(PUT).to.be.a('string');
-	});
-
-	it('API_RECONNECT_MAX_RETRY_COUNT should be an integer', () => {
-		return expect(API_RECONNECT_MAX_RETRY_COUNT).to.be.an.integer;
 	});
 
 	it('BETANET_NODES should be an array of strings', () => {


### PR DESCRIPTION
### What was the problem?
API_RECONNECT_MAX_RETRY_COUNT was exposed, but it should not be configurable.

### How did I fix it?
Remove from exposed constants and move it to where it was used.

### How to test it?
`console.log(LiskJS.APIClient.constnats)`

### Review checklist

* The PR solves #661 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
