### PR TITLE
Add functions for converting between LSK and Beddows - Closes #635

### DIFF
--- a/src/transactions/utils/format.js
+++ b/src/transactions/utils/format.js
@@ -12,6 +12,37 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import bignum from 'browserify-bignum';
+import { MAX_TRANSACTION_AMOUNT } from 'lisk-constants';
+import { FIXED_POINT } from '../constants';
+
+const getDecimalPlaces = amount => (amount.split('.')[1] || '').length;
+const isGreaterThanMaxTransactionAmount = amount =>
+	amount.cmp(MAX_TRANSACTION_AMOUNT) > 0;
+
+export const convertBeddowsToLSK = beddowsAmount => {
+	if (getDecimalPlaces(beddowsAmount)) {
+		throw new Error('Beddows amount should not have decimal points');
+	}
+	const beddowsAmountBigNum = bignum(beddowsAmount);
+	if (isGreaterThanMaxTransactionAmount(beddowsAmountBigNum)) {
+		throw new Error('Beddows amount out of range');
+	}
+	const lskAmountBigNum = beddowsAmountBigNum.div(FIXED_POINT);
+	return lskAmountBigNum.toString(10);
+};
+
+export const convertLSKToBeddows = lskAmount => {
+	if (getDecimalPlaces(lskAmount) > 8) {
+		throw new Error('LSK amount has too many decimal points');
+	}
+	const lskAmountBigNum = bignum(lskAmount);
+	const beddowsAmountBigNum = lskAmountBigNum.mul(FIXED_POINT);
+	if (isGreaterThanMaxTransactionAmount(beddowsAmountBigNum)) {
+		throw new Error('LSK amount out of range');
+	}
+	return beddowsAmountBigNum.toString();
+};
 
 export const prependPlusToPublicKeys = publicKeys =>
 	publicKeys.map(publicKey => `+${publicKey}`);

--- a/src/transactions/utils/format.js
+++ b/src/transactions/utils/format.js
@@ -21,6 +21,9 @@ const isGreaterThanMaxTransactionAmount = amount =>
 	amount.cmp(MAX_TRANSACTION_AMOUNT) > 0;
 
 export const convertBeddowsToLSK = beddowsAmount => {
+	if (typeof beddowsAmount !== 'string') {
+		throw new Error('Cannot convert non-string amount');
+	}
 	if (getDecimalPlaces(beddowsAmount)) {
 		throw new Error('Beddows amount should not have decimal points');
 	}
@@ -33,6 +36,9 @@ export const convertBeddowsToLSK = beddowsAmount => {
 };
 
 export const convertLSKToBeddows = lskAmount => {
+	if (typeof lskAmount !== 'string') {
+		throw new Error('Cannot convert non-string amount');
+	}
 	if (getDecimalPlaces(lskAmount) > 8) {
 		throw new Error('LSK amount has too many decimal points');
 	}

--- a/src/transactions/utils/index.js
+++ b/src/transactions/utils/index.js
@@ -18,7 +18,12 @@ export {
 export { default as getTransactionBytes } from './get_transaction_bytes';
 export { default as getTransactionHash } from './get_transaction_hash';
 export { default as getTransactionId } from './get_transaction_id';
-export { prependPlusToPublicKeys, prependMinusToPublicKeys } from './format';
+export {
+	convertBeddowsToLSK,
+	convertLSKToBeddows,
+	prependPlusToPublicKeys,
+	prependMinusToPublicKeys,
+} from './format';
 export { default as prepareTransaction } from './prepare_transaction';
 export {
 	signTransaction,

--- a/test/transactions/utils/format.js
+++ b/test/transactions/utils/format.js
@@ -13,11 +13,69 @@
  *
  */
 import {
+	convertBeddowsToLSK,
+	convertLSKToBeddows,
 	prependPlusToPublicKeys,
 	prependMinusToPublicKeys,
 } from 'transactions/utils/format';
 
 describe('format', () => {
+	describe('#convertBeddowsToLSK', () => {
+		it('should error on 18446744073709551615.1', () => {
+			return expect(
+				convertBeddowsToLSK.bind(null, '18446744073709551615.1'),
+			).to.throw('Beddows amount should not have decimal points');
+		});
+		it('should error on 0.1', () => {
+			return expect(convertBeddowsToLSK.bind(null, '0.1')).to.throw(
+				'Beddows amount should not have decimal points',
+			);
+		});
+		it('should error on 18446744073709551616', () => {
+			return expect(
+				convertBeddowsToLSK.bind(null, '18446744073709551616'),
+			).to.throw('Beddows amount out of range');
+		});
+		it('should convert 100000000 to 1', () => {
+			return expect(convertBeddowsToLSK('100000000')).to.equal('1');
+		});
+		it('should convert 1 to 0.00000001', () => {
+			return expect(convertBeddowsToLSK('1')).to.equal('0.00000001');
+		});
+		it('should convert 18446744073709551615 to 184467440737.09551615', () => {
+			return expect(convertBeddowsToLSK('18446744073709551615')).to.equal(
+				'184467440737.09551615',
+			);
+		});
+	});
+	describe('#convertLSKToBeddows', () => {
+		it('should error on 184467440737.095516151', () => {
+			return expect(
+				convertLSKToBeddows.bind(null, '184467440737.095516151'),
+			).to.throw('LSK amount has too many decimal points');
+		});
+		it('should error on 0.000000001', () => {
+			return expect(convertLSKToBeddows.bind(null, '0.000000001')).to.throw(
+				'LSK amount has too many decimal points',
+			);
+		});
+		it('should error on 184467440737.09551616', () => {
+			return expect(
+				convertLSKToBeddows.bind(null, '184467440737.09551616'),
+			).to.throw('LSK amount out of range');
+		});
+		it('should convert 1 to 100000000', () => {
+			return expect(convertLSKToBeddows('1')).to.equal('100000000');
+		});
+		it('should convert 0.00000001 to 1', () => {
+			return expect(convertLSKToBeddows('0.00000001')).to.equal('1');
+		});
+		it('should convert 184467440737.09551615 to 18446744073709551615', () => {
+			return expect(convertLSKToBeddows('184467440737.09551615')).to.equal(
+				'18446744073709551615',
+			);
+		});
+	});
 	describe('#prependPlusToPublicKeys', () => {
 		describe('Given an array of public keys', () => {
 			it('should append plus to each public key', () => {

--- a/test/transactions/utils/format.js
+++ b/test/transactions/utils/format.js
@@ -21,6 +21,11 @@ import {
 
 describe('format', () => {
 	describe('#convertBeddowsToLSK', () => {
+		it('should error if not given a string', () => {
+			return expect(convertBeddowsToLSK.bind(null, 12345678)).to.throw(
+				'Cannot convert non-string amount',
+			);
+		});
 		it('should error on 18446744073709551615.1', () => {
 			return expect(
 				convertBeddowsToLSK.bind(null, '18446744073709551615.1'),
@@ -49,6 +54,11 @@ describe('format', () => {
 		});
 	});
 	describe('#convertLSKToBeddows', () => {
+		it('should error if not given a string', () => {
+			return expect(convertLSKToBeddows.bind(null, 12345678)).to.throw(
+				'Cannot convert non-string amount',
+			);
+		});
 		it('should error on 184467440737.095516151', () => {
 			return expect(
 				convertLSKToBeddows.bind(null, '184467440737.095516151'),

--- a/test/transactions/utils/index.js
+++ b/test/transactions/utils/index.js
@@ -14,6 +14,8 @@
  */
 import {
 	checkPublicKeysForDuplicates,
+	convertBeddowsToLSK,
+	convertLSKToBeddows,
 	getAddressAndPublicKeyFromRecipientData,
 	getTimeFromBlockchainEpoch,
 	getTimeWithOffset,
@@ -38,6 +40,14 @@ describe('transaction utils', () => {
 	describe('exports', () => {
 		it('should have checkPublicKeysForDuplicates', () => {
 			return expect(checkPublicKeysForDuplicates).to.be.a('function');
+		});
+
+		it('should have convertBeddowsToLSK', () => {
+			return expect(convertBeddowsToLSK).to.be.a('function');
+		});
+
+		it('should have convertLSKToBeddows', () => {
+			return expect(convertLSKToBeddows).to.be.a('function');
 		});
 
 		it('should have getAddressAndPublicKeyFromRecipientData', () => {


### PR DESCRIPTION
### What was the problem?
We didn't have convenience functions for switching between LSK amounts and the smallest denomination.

### How did I fix it?
Added functions for that.

### How to test it?
`npm t`

### Review checklist

* The PR solves #635 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
