### PR TITLE
Add prefix bytes to signed message - Closes#673

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,9 @@
     "bip39": "=2.4.0",
     "browserify-bignum": "=1.3.0-2",
     "ed2curve": "=0.2.1",
-    "js-nacl": "LiskHQ/js-nacl#6dc1417",
-    "popsicle": "=9.1.0"
+	"js-nacl": "LiskHQ/js-nacl#6dc1417",
+	"popsicle": "=9.1.0",
+	"varuint-bitcoin": "=1.1.0"
   },
   "devDependencies": {
     "babel-cli": "=6.24.1",

--- a/package.json
+++ b/package.json
@@ -69,9 +69,9 @@
     "bip39": "=2.4.0",
     "browserify-bignum": "=1.3.0-2",
     "ed2curve": "=0.2.1",
-	"js-nacl": "LiskHQ/js-nacl#6dc1417",
-	"popsicle": "=9.1.0",
-	"varuint-bitcoin": "=1.1.0"
+    "js-nacl": "LiskHQ/js-nacl#6dc1417",
+    "popsicle": "=9.1.0",
+    "varuint-bitcoin": "=1.1.0"
   },
   "devDependencies": {
     "babel-cli": "=6.24.1",

--- a/src/cryptography/sign.js
+++ b/src/cryptography/sign.js
@@ -13,6 +13,7 @@
  *
  */
 import { encode as encodeVarInt } from 'varuint-bitcoin';
+import { SIGNED_MESSAGE_PREFIX } from 'lisk-constants';
 import hash from './hash';
 import { hexToBuffer, bufferToHex } from './convert';
 import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
@@ -26,7 +27,7 @@ const signatureHeader = createHeader('SIGNATURE');
 const secondSignatureHeader = createHeader('SECOND SIGNATURE');
 const signatureFooter = createHeader('END LISK SIGNED MESSAGE');
 
-const SIGNED_MESSAGE_PREFIX = Buffer.from('Lisk Signed Message:\n', 'utf8');
+const SIGNED_MESSAGE_PREFIX_BYTES = Buffer.from(SIGNED_MESSAGE_PREFIX, 'utf8');
 const SIGNED_MESSAGE_PREFIX_LENGTH = encodeVarInt(SIGNED_MESSAGE_PREFIX.length);
 
 export const digestMessage = message => {
@@ -35,7 +36,7 @@ export const digestMessage = message => {
 	const dataBytes = Buffer.concat(
 		[
 			SIGNED_MESSAGE_PREFIX_LENGTH,
-			SIGNED_MESSAGE_PREFIX,
+			SIGNED_MESSAGE_PREFIX_BYTES,
 			msgLenBytes,
 			msgBytes,
 		],

--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -21,6 +21,8 @@ export const MAX_ADDRESS_NUMBER = '18446744073709551615';
 // Largest possible amount. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
 export const MAX_TRANSACTION_AMOUNT = '18446744073709551615';
 
+export const SIGNED_MESSAGE_PREFIX = 'Lisk Signed Message:\n';
+
 export const BETANET_NETHASH =
 	'ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c';
 export const TESTNET_NETHASH =

--- a/test/cryptography/sign.js
+++ b/test/cryptography/sign.js
@@ -23,6 +23,7 @@ import {
 	signDataWithPassphrase,
 	signDataWithPrivateKey,
 	verifyData,
+	digestMessage,
 } from 'cryptography/sign';
 // Require is used for stubbing
 const keys = require('cryptography/keys');
@@ -48,9 +49,9 @@ describe('sign', () => {
 		'0401c8ac9f29ded9e1e4d5b6b43051cb25b22f27c7b7b35092161e851946f82f';
 	const defaultMessage = 'Some default text.';
 	const defaultSignature =
-		'974eeac2c7e7d9da42aa273c8caae8e6eb766fa29a31b37732f22e6d2e61e8402106849e61e3551ff70d7d359170a6198669e1061b6b4aa61997e26b87e3a704';
+		'68937004b6720d7e1902ef05a577e6d9f9ab2756286b1f2ae918f8a0e5153c15e4f410916076f750b708f8979be2430e4cfc7ebb523ae1905d2ea1f5d24ce700';
 	const defaultSecondSignature =
-		'fd938f69d33d70c940bb994579e11f4e5ee18e715634997ab9753305d5ec0d031aee03f6da8c1c259c1fdec34b4ef546e629c07bb3c77a4bcee9db017dac880d';
+		'58013cd8dbc4c194cedb5bdc27232f9de225d077b4dfe817ba810189486bd43e8600e0e8295623882e9db0ba5685bd30e7b7c81f38bc1b668fd9e2370ab9d905';
 	const defaultPrintedMessage = `
 -----BEGIN LISK SIGNED MESSAGE-----
 -----MESSAGE-----
@@ -114,6 +115,45 @@ ${defaultSecondSignature}
 				privateKey: Buffer.from(defaultSecondPrivateKey, 'hex'),
 				publicKey: Buffer.from(defaultSecondPublicKey, 'hex'),
 			});
+	});
+
+	describe('#digestMessage', () => {
+		const strGenerator = (len, chr) => chr.repeat(len);
+
+		it('should create message digest for message with length = 0', () => {
+			const msgBytes = digestMessage('');
+			const expectedMessageBytes = Buffer.from(
+				'3fdb82ac2a879b647f4f27f3fbd1c27e0d4e278f830b76295604035330163b79',
+				'hex',
+			);
+			return expect(msgBytes).to.be.eql(expectedMessageBytes);
+		});
+		it('should create message digest for message in length range 1 - 253', () => {
+			const msgBytes = digestMessage(strGenerator(250, 'a'));
+			const expectedMessageBytes = Buffer.from(
+				'12832c687d950513aa5db6198b84809eb8fd7ff1c8963dca48ea57278523ec67',
+				'hex',
+			);
+			return expect(msgBytes).to.be.eql(expectedMessageBytes);
+		});
+		it('should create message digest for message in length range 254 - 65536', () => {
+			const msgBytes = digestMessage(strGenerator(65535, 'a'));
+			const expectedMessageBytes = Buffer.from(
+				'73da94220312e71eb5c55c94fdddca3c06a6c18cb74a4a4a2cee1a82875c2450',
+				'hex',
+			);
+			return expect(msgBytes).to.be.eql(expectedMessageBytes);
+		});
+		it('should create message digest for message in length range 65537 - 4294967296', () => {
+			const msgBytes = digestMessage(strGenerator(6710886, 'a'));
+			const expectedMessageBytes = Buffer.from(
+				'7c51817b5c31c4d04e9ffcf2e78859d6522b124f218c789a8f721b5f3e6b295d',
+				'hex',
+			);
+			return expect(msgBytes).to.be.eql(expectedMessageBytes);
+		});
+		// higest range (length > 4294967296) is not practical to test
+		// but it is covered by `varuint-bitcoin` library
 	});
 
 	describe('#signMessageWithPassphrase', () => {

--- a/test/lisk-constants/index.js
+++ b/test/lisk-constants/index.js
@@ -21,6 +21,7 @@ import {
 	BETANET_NETHASH,
 	TESTNET_NETHASH,
 	MAINNET_NETHASH,
+	SIGNED_MESSAGE_PREFIX,
 } from 'lisk-constants';
 
 describe('lisk-constants', () => {
@@ -54,5 +55,9 @@ describe('lisk-constants', () => {
 
 	it('MAINNET_NETHASH should be a string', () => {
 		return expect(MAINNET_NETHASH).to.be.a('string');
+	});
+
+	it('SIGNED_MESSAGE_PREFIX should be a string', () => {
+		return expect(SIGNED_MESSAGE_PREFIX).to.be.a('string');
 	});
 });


### PR DESCRIPTION
### What was the problem?
Lisk signed message doesn't have a header prefix

### How did I fix it?
Calculate message signature with this formula:
~~sign (Lisk Signed Message:\n + message length + message)~~
```

digest = sha256(sha256(
  varint(len(prefix)) + prefix + varint(len(message)) + message
))

sign(dugest)
```

### How to test it?
run tests

### Review checklist

* The PR solves #673 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated