### PR TITLE
Replace crypto library with tweetnacl-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "bip39": "=2.4.0",
     "browserify-bignum": "=1.3.0-2",
     "ed2curve": "=0.2.1",
-    "js-nacl": "LiskHQ/js-nacl#6dc1417",
+    "js-sha256": "^0.6.0",
+    "tweetnacl": "^1.0.0",
+    "tweetnacl-util": "^0.15.0",
     "varuint-bitcoin": "=1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -70,9 +70,7 @@
     "bip39": "=2.4.0",
     "browserify-bignum": "=1.3.0-2",
     "ed2curve": "=0.2.1",
-    "js-sha256": "^0.6.0",
-    "tweetnacl": "^1.0.0",
-    "tweetnacl-util": "^0.15.0",
+    "tweetnacl": "=1.0.0",
     "varuint-bitcoin": "=1.1.0"
   },
   "devDependencies": {

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -23,7 +23,9 @@ export const bigNumberToBuffer = (bignumber, size) =>
 export const bufferToBigNumberString = bigNumberBuffer =>
 	bignum.fromBuffer(bigNumberBuffer).toString();
 
-export const bufferToHex = buffer => naclInstance.to_hex(buffer);
+// @todo replace Buffer constructor
+// eslint-disable-next-line no-buffer-constructor
+export const bufferToHex = buffer => new Buffer(buffer).toString('hex');
 
 const hexRegex = /^[0-9a-f]+/i;
 export const hexToBuffer = hex => {

--- a/src/cryptography/encrypt.js
+++ b/src/cryptography/encrypt.js
@@ -38,7 +38,7 @@ export const encryptMessageWithPassphrase = (
 	const convertedPrivateKey = convertPrivateKeyEd2Curve(senderPrivateKeyBytes);
 	const recipientPublicKeyBytes = hexToBuffer(recipientPublicKey);
 	const convertedPublicKey = convertPublicKeyEd2Curve(recipientPublicKeyBytes);
-	const messageInBytes = nacl.util.decodeUTF8(message);
+	const messageInBytes = Buffer.from(message, 'utf8');
 
 	const nonce = nacl.randomBytes(24);
 	const cipherBytes = nacl.box(
@@ -81,7 +81,7 @@ export const decryptMessageWithPassphrase = (
 			convertedPublicKey,
 			convertedPrivateKey,
 		);
-		return nacl.util.encodeUTF8(decoded);
+		return Buffer.from(decoded).toString();
 	} catch (error) {
 		if (error.message.match(/bad nonce size/)) {
 			throw new Error('Expected 24-byte nonce but got length 1.');

--- a/src/cryptography/encrypt.js
+++ b/src/cryptography/encrypt.js
@@ -13,6 +13,7 @@
  *
  */
 import crypto from 'crypto';
+import nacl from 'tweetnacl';
 import {
 	hexToBuffer,
 	bufferToHex,
@@ -37,10 +38,10 @@ export const encryptMessageWithPassphrase = (
 	const convertedPrivateKey = convertPrivateKeyEd2Curve(senderPrivateKeyBytes);
 	const recipientPublicKeyBytes = hexToBuffer(recipientPublicKey);
 	const convertedPublicKey = convertPublicKeyEd2Curve(recipientPublicKeyBytes);
-	const messageInBytes = naclInstance.encode_utf8(message);
+	const messageInBytes = nacl.util.decodeUTF8(message);
 
-	const nonce = naclInstance.crypto_box_random_nonce();
-	const cipherBytes = naclInstance.crypto_box(
+	const nonce = nacl.randomBytes(24);
+	const cipherBytes = nacl.box(
 		messageInBytes,
 		nonce,
 		convertedPublicKey,
@@ -74,19 +75,15 @@ export const decryptMessageWithPassphrase = (
 	const nonceBytes = hexToBuffer(nonce);
 
 	try {
-		const decoded = naclInstance.crypto_box_open(
+		const decoded = nacl.box.open(
 			cipherBytes,
 			nonceBytes,
 			convertedPublicKey,
 			convertedPrivateKey,
 		);
-		return naclInstance.decode_utf8(decoded);
+		return nacl.util.encodeUTF8(decoded);
 	} catch (error) {
-		if (
-			error.message.match(
-				/nacl\.crypto_box_open expected 24-byte nonce but got length 1/,
-			)
-		) {
+		if (error.message.match(/bad nonce size/)) {
 			throw new Error('Expected 24-byte nonce but got length 1.');
 		}
 		throw new Error(

--- a/src/cryptography/hash.js
+++ b/src/cryptography/hash.js
@@ -12,9 +12,22 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import nacl from 'tweetnacl';
+import naclUtil from 'tweetnacl-util';
+import sha256 from 'js-sha256';
+import { hexToBuffer } from './convert';
+
+nacl.util = naclUtil;
+
+const cryptoHashSha256 = data => {
+	const hash = sha256.create();
+	hash.update(data);
+	return new Uint8Array(hash.array());
+};
+
 const hash = (data, format) => {
 	if (Buffer.isBuffer(data)) {
-		return Buffer.from(naclInstance.crypto_hash_sha256(data));
+		return Buffer.from(cryptoHashSha256(data)); // :: should I remove Buffer.from?
 	}
 
 	if (typeof data === 'string') {
@@ -24,10 +37,8 @@ const hash = (data, format) => {
 			);
 		}
 		const encoded =
-			format === 'utf8'
-				? naclInstance.encode_utf8(data)
-				: naclInstance.from_hex(data);
-		return Buffer.from(naclInstance.crypto_hash_sha256(encoded));
+			format === 'utf8' ? nacl.util.decodeUTF8(data) : hexToBuffer(data);
+		return cryptoHashSha256(encoded);
 	}
 
 	throw new Error(

--- a/src/cryptography/hash.js
+++ b/src/cryptography/hash.js
@@ -12,22 +12,18 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import nacl from 'tweetnacl';
-import naclUtil from 'tweetnacl-util';
-import sha256 from 'js-sha256';
+import crypto from 'crypto';
 import { hexToBuffer } from './convert';
 
-nacl.util = naclUtil;
-
 const cryptoHashSha256 = data => {
-	const hash = sha256.create();
+	const hash = crypto.createHash('sha256');
 	hash.update(data);
-	return new Uint8Array(hash.array());
+	return hash.digest();
 };
 
 const hash = (data, format) => {
 	if (Buffer.isBuffer(data)) {
-		return Buffer.from(cryptoHashSha256(data)); // :: should I remove Buffer.from?
+		return cryptoHashSha256(data);
 	}
 
 	if (typeof data === 'string') {
@@ -37,7 +33,7 @@ const hash = (data, format) => {
 			);
 		}
 		const encoded =
-			format === 'utf8' ? nacl.util.decodeUTF8(data) : hexToBuffer(data);
+			format === 'utf8' ? Buffer.from(data, 'utf8') : hexToBuffer(data);
 		return cryptoHashSha256(encoded);
 	}
 

--- a/src/cryptography/keys.js
+++ b/src/cryptography/keys.js
@@ -12,16 +12,17 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import nacl from 'tweetnacl';
 import { bufferToHex, getAddressFromPublicKey } from './convert';
 import hash from './hash';
 
 export const getPrivateAndPublicKeyBytesFromPassphrase = passphrase => {
-	const hashed = hash(passphrase, 'utf8');
-	const { signSk, signPk } = naclInstance.crypto_sign_seed_keypair(hashed);
+	const hashed = hash(passphrase, 'utf8'); // :: Is getSha256Hash the same as hash function?
+	const { publicKey, secretKey } = nacl.sign.keyPair.fromSeed(hashed);
 
 	return {
-		privateKey: signSk,
-		publicKey: signPk,
+		privateKey: secretKey,
+		publicKey,
 	};
 };
 

--- a/src/cryptography/sign.js
+++ b/src/cryptography/sign.js
@@ -13,14 +13,11 @@
  *
  */
 import nacl from 'tweetnacl';
-import naclUtil from 'tweetnacl-util';
 import { encode as encodeVarInt } from 'varuint-bitcoin';
 import { SIGNED_MESSAGE_PREFIX } from 'lisk-constants';
 import hash from './hash';
 import { hexToBuffer, bufferToHex } from './convert';
 import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
-
-nacl.util = naclUtil;
 
 const createHeader = text => `-----${text}-----`;
 const signedMessageHeader = createHeader('BEGIN LISK SIGNED MESSAGE');

--- a/src/index.js
+++ b/src/index.js
@@ -12,19 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import naclFactory from 'js-nacl';
 import APIClient from './api_client';
 import cryptography from './cryptography';
 import * as constants from './lisk-constants';
 import passphrase from './passphrase';
 import transaction from './transactions';
-
-global.naclFactory = naclFactory;
-
-global.naclInstance = null;
-naclFactory.instantiate(nacl => {
-	naclInstance = nacl;
-});
 
 export default {
 	APIClient,

--- a/test/setup.js
+++ b/test/setup.js
@@ -17,7 +17,6 @@ import chai, { Assertion } from 'chai';
 import 'chai/register-expect';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
-import naclFactory from 'js-nacl';
 
 process.env.NODE_ENV = 'test';
 
@@ -55,9 +54,3 @@ global.sinon = sinon;
 global.sandbox = sinon.sandbox.create({
 	useFakeTimers: true,
 });
-
-if (!global.naclInstance) {
-	naclFactory.instantiate(nacl => {
-		global.naclInstance = nacl;
-	});
-}


### PR DESCRIPTION
### What was the problem?

js-nacl was out of date with libsodium, unmaintained, and incompatible with React Native.

### How did I fix it?

Replaced js-nacl with tweetnacl-js

### How to test it?

Try to use crypto functions, e.g. in a React Native environment.

### Review checklist

* The PR solves #435 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
