### PR TITLE
Add conditional build postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "build:check": "node -e \"require('./dist-node')\"",
     "precommit": "lint-staged && npm run lint",
     "prepush": "npm run lint && npm test",
+    "postinstall": "if [ ! -f ./dist-node/index.js ]; then npm run build; fi",
     "prepublishOnly": "rm -r ./node_modules && npm install && npm run prepush && npm run build",
     "prepublish:browser": "npm run prepublishOnly",
     "publish:browser": "./bin/publish_browser.sh",


### PR DESCRIPTION
### What was the problem?

If installing using npm via GitHub (e.g. specifying a GitHub commit in a project's `package.json`), `dist-node` would be missing, leading to an incomplete installation.

### How did I fix it?

Added a `postinstall` check to see if the `dist-node` files exist, and if not build them.

### How to test it?

### Review checklist

* The PR solves #686 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
