### PR TITLE
Output default iterations when encrypting passphrases

### DIFF
--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -86,6 +86,17 @@ export const stringifyEncryptedPassphrase = encryptedPassphrase => {
 	return querystring.stringify(objectToStringify);
 };
 
+const parseIterations = iterationsString => {
+	const iterations =
+		iterationsString === undefined ? undefined : parseInt(iterationsString, 10);
+
+	if (Number.isNaN(iterations)) {
+		throw new Error('Could not parse iterations.');
+	}
+
+	return iterations;
+};
+
 export const parseEncryptedPassphrase = encryptedPassphrase => {
 	if (typeof encryptedPassphrase !== 'string') {
 		throw new Error('Encrypted passphrase to parse must be a string.');
@@ -94,7 +105,7 @@ export const parseEncryptedPassphrase = encryptedPassphrase => {
 	const { iterations, salt, cipherText, iv, tag, version } = keyValuePairs;
 
 	return {
-		iterations: iterations === undefined ? undefined : parseInt(iterations, 10),
+		iterations: parseIterations(iterations),
 		salt,
 		cipherText,
 		iv,

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -91,14 +91,10 @@ export const parseEncryptedPassphrase = encryptedPassphrase => {
 		throw new Error('Encrypted passphrase to parse must be a string.');
 	}
 	const keyValuePairs = querystring.parse(encryptedPassphrase);
-	const { salt, cipherText, iv, tag, version } = keyValuePairs;
-	const iterations =
-		keyValuePairs.iterations !== undefined
-			? parseInt(keyValuePairs.iterations, 10)
-			: null;
+	const { iterations, salt, cipherText, iv, tag, version } = keyValuePairs;
 
 	return {
-		iterations,
+		iterations: iterations === undefined ? undefined : parseInt(iterations, 10),
 		salt,
 		cipherText,
 		iv,

--- a/src/cryptography/encrypt.js
+++ b/src/cryptography/encrypt.js
@@ -96,12 +96,16 @@ const getKeyFromPassword = (password, salt, iterations) =>
 	crypto.pbkdf2Sync(
 		password,
 		salt,
-		iterations || PBKDF2_ITERATIONS,
+		iterations,
 		PBKDF2_KEYLEN,
 		PBKDF2_HASH_FUNCTION,
 	);
 
-const encryptAES256GCMWithPassword = (plainText, password, iterations) => {
+const encryptAES256GCMWithPassword = (
+	plainText,
+	password,
+	iterations = PBKDF2_ITERATIONS,
+) => {
 	const iv = crypto.randomBytes(12);
 	const salt = crypto.randomBytes(16);
 	const key = getKeyFromPassword(password, salt, iterations);
@@ -112,7 +116,7 @@ const encryptAES256GCMWithPassword = (plainText, password, iterations) => {
 	const tag = cipher.getAuthTag();
 
 	return {
-		iterations: iterations || null,
+		iterations,
 		cipherText: encrypted.toString('hex'),
 		iv: iv.toString('hex'),
 		salt: salt.toString('hex'),
@@ -130,7 +134,7 @@ const getTagBuffer = tag => {
 };
 
 const decryptAES256GCMWithPassword = (
-	{ iterations, cipherText, iv, salt, tag },
+	{ iterations = PBKDF2_ITERATIONS, cipherText, iv, salt, tag },
 	password,
 ) => {
 	const tagBuffer = getTagBuffer(tag);

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -256,6 +256,14 @@ describe('convert', () => {
 			).to.throw('Encrypted passphrase to parse must be a string.');
 		});
 
+		it('should throw an error if iterations is present but not a valid number', () => {
+			const stringifiedEncryptedPassphrase =
+				'iterations=null&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
+			return expect(
+				parseEncryptedPassphrase.bind(null, stringifiedEncryptedPassphrase),
+			).to.throw('Could not parse iterations.');
+		});
+
 		it('should parse an encrypted passphrase string', () => {
 			const stringifiedEncryptedPassphrase =
 				'salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';

--- a/test/cryptography/convert.js
+++ b/test/cryptography/convert.js
@@ -260,7 +260,7 @@ describe('convert', () => {
 			const stringifiedEncryptedPassphrase =
 				'salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
 			const encryptedPassphrase = {
-				iterations: null,
+				iterations: undefined,
 				salt: 'e8c7dae4c893e458e0ebb8bff9a36d84',
 				cipherText:
 					'c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333',

--- a/test/cryptography/encrypt.js
+++ b/test/cryptography/encrypt.js
@@ -1,5 +1,4 @@
-/*
- * Copyright © 2018 Lisk Foundation
+/** Copyright © 2018 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -24,6 +23,7 @@ const keys = require('cryptography/keys');
 const hash = require('cryptography/hash');
 
 describe('encrypt', () => {
+	const PBKDF2_ITERATIONS = 1e6;
 	const ENCRYPTION_VERSION = '1';
 	const defaultPassphrase =
 		'minute omit local rare sword knee banner pair rib museum shadow juice';
@@ -212,9 +212,10 @@ describe('encrypt', () => {
 					.which.is.equal(ENCRYPTION_VERSION);
 			});
 
-			it('should not output the default number of iterations', () => {
-				return expect(encryptedPassphrase).to.have.property('iterations').be
-					.null;
+			it('should output the default number of iterations', () => {
+				return expect(encryptedPassphrase)
+					.to.have.property('iterations')
+					.equal(PBKDF2_ITERATIONS);
 			});
 
 			it('should take more than 0.5 seconds @node-only', () => {
@@ -244,7 +245,7 @@ describe('encrypt', () => {
 
 			beforeEach(() => {
 				encryptedPassphrase = {
-					iterations: null,
+					iterations: undefined,
 					cipherText:
 						'5cfd7bcc13022a482e7c8bd250cd73ef3eb7c49c849d5e761ce717608293f777cca8e0e18587ee307beab65bcc1b273caeb23d4985010b675391b354c38f8e84e342c1e7aa',
 					iv: '7b820ad6936a63152d13ffa2',


### PR DESCRIPTION
### What was the problem?

We didn't output the default number of iterations when encrypting passphrases.

### How did I fix it?

Better to be explicit.

### How to test it?

Encrypt a passphrase without specifying the number of iterations.

### Review checklist

* The PR solves #685 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
