### PR TITLE
Sort delegates properly in API call

### DIFF
--- a/src/api_client/resources/delegates.js
+++ b/src/api_client/resources/delegates.js
@@ -24,12 +24,15 @@ export default class DelegatesResource extends APIResource {
 
 		this.get = apiMethod({
 			method: GET,
+			defaultData: {
+				sort: 'rank:asc',
+			},
 		}).bind(this);
 
 		this.getStandby = apiMethod({
 			method: GET,
 			defaultData: {
-				sort: 'rate:asc',
+				sort: 'rank:asc',
 				offset: 101,
 			},
 		}).bind(this);


### PR DESCRIPTION
### What was the problem?

We weren't sorting delegates appropriately.

### How did I fix it?

I fixed `getStandby` to use a valid sort order, and changed `get` to sort by `rank:asc` (see LiskHQ/lisk#2138).

### How to test it?

### Review checklist

* The PR solves #691 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
