### PR TITLE
Use shared jenkins library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,29 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-def get_build_info() {
-	pr_branch = ''
-	if (env.CHANGE_BRANCH != null) {
-		pr_branch = " (${env.CHANGE_BRANCH})"
-	}
-	build_info = "#${env.BUILD_NUMBER} of <${env.BUILD_URL}|${env.JOB_NAME}>${pr_branch}"
-	return build_info
-}
-
-def slack_send(color, message) {
-	/* Slack channel names are limited to 21 characters */
-	CHANNEL_MAX_LEN = 21
-
-	channel = "${env.JOB_NAME}".tokenize('/')[0]
-	channel = channel.replace('lisk-', 'lisk-ci-')
-	if ( channel.size() > CHANNEL_MAX_LEN ) {
-		 channel = channel.substring(0, CHANNEL_MAX_LEN)
-	}
-
-	echo "[slack_send] channel: ${channel} "
-	slackSend color: "${color}", message: "${message}", channel: "${channel}"
-}
-
+@Library('lisk-jenkins') _
 pipeline {
 	agent { node { label 'lisk-elements' } }
 	stages {
@@ -81,16 +59,16 @@ pipeline {
 	post {
 		success {
 			script {
-				build_info = get_build_info()
-				slack_send('good', "Recovery: build ${build_info} was successful.")
+				build_info = getBuildInfo()
+				liskSlackSend('good', "Recovery: build ${build_info} was successful.")
 			}
 			deleteDir()
 			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build passed.', status: 'SUCCESS'
 		}
 		failure {
 			script {
-				build_info = get_build_info()
-				slack_send('danger', "Build ${build_info} failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)\n")
+				build_info = getBuildInfo()
+				liskSlackSend('danger', "Build ${build_info} failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)\n")
 			}
 			archiveArtifacts allowEmptyArchive: true, artifacts: 'cypress/screenshots/'
 			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build failed.', status: 'FAILURE'


### PR DESCRIPTION
### What was the problem?

Jenkinsfile was using functions shared across projects that can be imported now from https://github.com/LiskHQ/lisk-jenkins

### How did I fix it?

Remove functions and add import

### How to test it?

Tested in Jenkins itself 
