### PR TITLE
Update testnet node to use https - Closes #703

### DIFF
--- a/src/api_client/constants.js
+++ b/src/api_client/constants.js
@@ -16,7 +16,7 @@ export const GET = 'GET';
 export const POST = 'POST';
 export const PUT = 'PUT';
 
-export const TESTNET_NODES = ['http://testnet.lisk.io:7000'];
+export const TESTNET_NODES = ['https://testnet.lisk.io:443'];
 export const MAINNET_NODES = [
 	'https://node01.lisk.io:443',
 	'https://node02.lisk.io:443',

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -30,7 +30,7 @@ describe('APIClient module', () => {
 	];
 	const testnetHash =
 		'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
-	const testnetNodes = ['http://testnet.lisk.io:7000'];
+	const testnetNodes = ['https://testnet.lisk.io:443'];
 	const locale =
 		process.env.LC_ALL ||
 		process.env.LC_MESSAGES ||


### PR DESCRIPTION
### What was the problem?

We were using http on testnet.

### How did I fix it?

Updated testnet node to use https.

### How to test it?

`lisk.APIClient.createTestnetAPIClient().transactions.get().then(console.log)`

### Review checklist

* The PR solves #703 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
