### PR TITLE
Add validation to decrypt passphrase - Closes #688

### DIFF
--- a/packages/lisk-cryptography/src/convert.js
+++ b/packages/lisk-cryptography/src/convert.js
@@ -26,16 +26,18 @@ export const bufferToBigNumberString = bigNumberBuffer =>
 export const bufferToHex = buffer => Buffer.from(buffer).toString('hex');
 
 const hexRegex = /^[0-9a-f]+/i;
-export const hexToBuffer = hex => {
+export const hexToBuffer = (hex, argumentName = 'Argument') => {
 	if (typeof hex !== 'string') {
-		throw new TypeError('Argument must be a string.');
+		throw new TypeError(`${argumentName} must be a string.`);
 	}
 	const matchedHex = (hex.match(hexRegex) || [])[0];
 	if (!matchedHex || matchedHex.length !== hex.length) {
-		throw new TypeError('Argument must be a valid hex string.');
+		throw new TypeError(`${argumentName} must be a valid hex string.`);
 	}
 	if (matchedHex.length % 2 !== 0) {
-		throw new TypeError('Argument must have a valid length of hex string.');
+		throw new TypeError(
+			`${argumentName} must have a valid length of hex string.`,
+		);
 	}
 	return Buffer.from(matchedHex, 'hex');
 };
@@ -82,7 +84,7 @@ export const stringifyEncryptedPassphrase = encryptedPassphrase => {
 				iv: encryptedPassphrase.iv,
 				tag: encryptedPassphrase.tag,
 				version: encryptedPassphrase.version,
-		  };
+			};
 	return querystring.stringify(objectToStringify);
 };
 

--- a/packages/lisk-cryptography/test/convert.js
+++ b/packages/lisk-cryptography/test/convert.js
@@ -81,6 +81,12 @@ describe('convert', () => {
 			);
 		});
 
+		it('should throw an error for a non-string input with custom argument name', () => {
+			return expect(hexToBuffer.bind(null, {}, 'Custom')).to.throw(
+				'Custom must be a string.',
+			);
+		});
+
 		it('should throw TypeError with non hex string', () => {
 			return expect(hexToBuffer.bind(null, 'yKJj')).to.throw(
 				TypeError,
@@ -109,10 +115,22 @@ describe('convert', () => {
 			);
 		});
 
-		it('should throw TypeError with odd number of hex string', () => {
+		it('should throw an error for a non-hex string input with custom argument name', () => {
+			return expect(hexToBuffer.bind(null, 'yKJj', 'Custom')).to.throw(
+				'Custom must be a valid hex string.',
+			);
+		});
+
+		it('should throw TypeError with odd-length hex string', () => {
 			return expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a')).to.throw(
 				TypeError,
 				'Argument must have a valid length of hex string.',
+			);
+		});
+
+		it('should throw an error for an odd-length hex string input with custom argument name', () => {
+			return expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a', 'Custom')).to.throw(
+				'Custom must have a valid length of hex string.',
 			);
 		});
 	});

--- a/packages/lisk-cryptography/test/encrypt.js
+++ b/packages/lisk-cryptography/test/encrypt.js
@@ -264,6 +264,50 @@ describe('encrypt', () => {
 				return expect(decrypted).to.be.equal(defaultPassphrase);
 			});
 
+			it('should inform the user if cipherText is missing', () => {
+				delete encryptedPassphrase.cipherText;
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						encryptedPassphrase,
+						defaultPassword,
+					),
+				).to.throw('Cipher text must be a string.');
+			});
+
+			it('should inform the user if iv is missing', () => {
+				delete encryptedPassphrase.iv;
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						encryptedPassphrase,
+						defaultPassword,
+					),
+				).to.throw('IV must be a string.');
+			});
+
+			it('should inform the user if salt is missing', () => {
+				delete encryptedPassphrase.salt;
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						encryptedPassphrase,
+						defaultPassword,
+					),
+				).to.throw('Salt must be a string.');
+			});
+
+			it('should inform the user if tag is missing', () => {
+				delete encryptedPassphrase.tag;
+				return expect(
+					decryptPassphraseWithPassword.bind(
+						null,
+						encryptedPassphrase,
+						defaultPassword,
+					),
+				).to.throw('Tag must be a string.');
+			});
+
 			it('should inform the user if the salt has been altered', () => {
 				encryptedPassphrase.salt = `00${encryptedPassphrase.salt.slice(2)}`;
 				return expect(
@@ -294,7 +338,7 @@ describe('encrypt', () => {
 						encryptedPassphrase,
 						defaultPassword,
 					),
-				).to.throw('Argument must be a valid hex string.');
+				).to.throw('Tag must be a valid hex string.');
 			});
 
 			it('should inform the user if the tag has been altered', () => {


### PR DESCRIPTION
Closes #688

### What was the problem?

We had no validation when decrypting passphrases, with unhelpful error messages.

### How did I fix it?

Added validation and helpful error messages.

### How to test it?

Try to decrypt a passphrase with some missing parameters.

### Review checklist

* The PR solves #688 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
