### PR TITLE
Disable user-agent header when client options were not provided - Closes #696

### DIFF
--- a/packages/lisk-api-client/src/api_client.js
+++ b/packages/lisk-api-client/src/api_client.js
@@ -38,9 +38,13 @@ const commonHeaders = {
 	'Content-Type': 'application/json',
 };
 
-const getUserAgent = (
-	{ name = '????', version = '????', engine = '????' } = {},
-) => {
+const getClientHeaders = clientOptions => {
+	if (!clientOptions) {
+		return {};
+	}
+
+	const { name = '????', version = '????', engine = '????' } = clientOptions;
+
 	const liskElementsInformation =
 		'LiskElements/1.0 (+https://github.com/LiskHQ/lisk-elements)';
 	const locale =
@@ -51,9 +55,7 @@ const getUserAgent = (
 	const systemInformation = `${os.platform()} ${os.release()}; ${os.arch()}${
 		locale ? `; ${locale}` : ''
 	}`;
-	return `${name}/${version} (${engine}) ${liskElementsInformation} ${
-		systemInformation
-	}`;
+	return `${name}/${version} (${engine}) ${liskElementsInformation} ${systemInformation}`;
 };
 
 export default class APIClient {
@@ -107,9 +109,7 @@ export default class APIClient {
 			{},
 			commonHeaders,
 			options.nethash ? { nethash: options.nethash } : {},
-			{
-				'User-Agent': getUserAgent(options.client),
-			},
+			getClientHeaders(options.client),
 		);
 
 		this.nodes = nodes;

--- a/packages/lisk-api-client/test/api_client.js
+++ b/packages/lisk-api-client/test/api_client.js
@@ -198,7 +198,6 @@ describe('APIClient module', () => {
 
 			it('should set custom headers with supplied options', () => {
 				apiClient = new APIClient(defaultNodes, {
-					version: customHeaders.version,
 					nethash: testnetHash,
 					client: {
 						name: 'LiskHub',
@@ -209,6 +208,13 @@ describe('APIClient module', () => {
 				return expect(apiClient)
 					.to.have.property('headers')
 					.and.eql(customHeaders);
+			});
+
+			it('should not set User-Agent header when client options were not given', () => {
+				apiClient = new APIClient(defaultNodes, {
+					nethash: testnetHash,
+				});
+				return expect(apiClient.headers).to.not.have.property('User-Agent');
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
lisk-elements is throwing Refused to set unsafe header “User-Agent”warning when it's used in browsers.
### How did I fix it?
I updated getUserAgent function to return empty object when clientOptions were not provided.
### How to test it?
should not set User-Agent header when client options were not given
### Review checklist

* The PR solves #696 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
