### PR TITLE
Use React Native/Android-compatible buffer reverse function - Closes #710

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "babel-runtime": "=6.26.0",
     "bip39": "=2.4.0",
     "browserify-bignum": "=1.3.0-2",
+    "buffer-reverse": "=1.0.1",
     "ed2curve": "=0.2.1",
     "tweetnacl": "=1.0.0",
     "varuint-bitcoin": "=1.1.0"

--- a/src/cryptography/convert.js
+++ b/src/cryptography/convert.js
@@ -14,6 +14,7 @@
  */
 import querystring from 'querystring';
 import bignum from 'browserify-bignum';
+import reverseBuffer from 'buffer-reverse';
 import ed2curve from 'ed2curve';
 import hash from './hash';
 
@@ -41,9 +42,7 @@ export const hexToBuffer = hex => {
 };
 
 export const getFirstEightBytesReversed = publicKeyBytes =>
-	Buffer.from(publicKeyBytes)
-		.slice(0, 8)
-		.reverse();
+	reverseBuffer(Buffer.from(publicKeyBytes).slice(0, 8));
 
 export const toAddress = buffer => {
 	if (


### PR DESCRIPTION
### What was the problem?

Using `.reverse` on buffers isn't supported in the React Native/Android environment.

### How did I fix it?

Used a library which will implement reverse for buffers.

### How to test it?

Try to use `getFirstEightBytesReversed` in particular (plus other functions) in React Native/Android.

### Review checklist

* The PR solves #710 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
