### PR TITLE
Update maximum transaction amount - Closes #763

### DIFF
--- a/src/lisk-constants/index.js
+++ b/src/lisk-constants/index.js
@@ -18,8 +18,8 @@ export const EPOCH_TIME_SECONDS = Math.floor(EPOCH_TIME.getTime() / 1000);
 
 // Largest possible address. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
 export const MAX_ADDRESS_NUMBER = '18446744073709551615';
-// Largest possible amount. Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
-export const MAX_TRANSACTION_AMOUNT = '18446744073709551615';
+// Largest possible amount. Equal to the initial supply.
+export const MAX_TRANSACTION_AMOUNT = '10000000000000000';
 
 export const SIGNED_MESSAGE_PREFIX = 'Lisk Signed Message:\n';
 

--- a/test/transactions/utils/format.js
+++ b/test/transactions/utils/format.js
@@ -26,19 +26,14 @@ describe('format', () => {
 				'Cannot convert non-string amount',
 			);
 		});
-		it('should error on 18446744073709551615.1', () => {
-			return expect(
-				convertBeddowsToLSK.bind(null, '18446744073709551615.1'),
-			).to.throw('Beddows amount should not have decimal points');
-		});
 		it('should error on 0.1', () => {
 			return expect(convertBeddowsToLSK.bind(null, '0.1')).to.throw(
 				'Beddows amount should not have decimal points',
 			);
 		});
-		it('should error on 18446744073709551616', () => {
+		it('should error on 10000000000000001', () => {
 			return expect(
-				convertBeddowsToLSK.bind(null, '18446744073709551616'),
+				convertBeddowsToLSK.bind(null, '10000000000000001'),
 			).to.throw('Beddows amount out of range');
 		});
 		it('should convert 100000000 to 1', () => {
@@ -47,9 +42,14 @@ describe('format', () => {
 		it('should convert 1 to 0.00000001', () => {
 			return expect(convertBeddowsToLSK('1')).to.equal('0.00000001');
 		});
-		it('should convert 18446744073709551615 to 184467440737.09551615', () => {
-			return expect(convertBeddowsToLSK('18446744073709551615')).to.equal(
-				'184467440737.09551615',
+		it('should convert 10000000000000000 to 100000000', () => {
+			return expect(convertBeddowsToLSK('10000000000000000')).to.equal(
+				'100000000',
+			);
+		});
+		it('should convert 9999999999999999 to 99999999.99999999', () => {
+			return expect(convertBeddowsToLSK('9999999999999999')).to.equal(
+				'99999999.99999999',
 			);
 		});
 	});
@@ -59,19 +59,14 @@ describe('format', () => {
 				'Cannot convert non-string amount',
 			);
 		});
-		it('should error on 184467440737.095516151', () => {
-			return expect(
-				convertLSKToBeddows.bind(null, '184467440737.095516151'),
-			).to.throw('LSK amount has too many decimal points');
-		});
 		it('should error on 0.000000001', () => {
 			return expect(convertLSKToBeddows.bind(null, '0.000000001')).to.throw(
 				'LSK amount has too many decimal points',
 			);
 		});
-		it('should error on 184467440737.09551616', () => {
+		it('should error on 100000000.00000001', () => {
 			return expect(
-				convertLSKToBeddows.bind(null, '184467440737.09551616'),
+				convertLSKToBeddows.bind(null, '100000000.00000001'),
 			).to.throw('LSK amount out of range');
 		});
 		it('should convert 1 to 100000000', () => {
@@ -80,9 +75,14 @@ describe('format', () => {
 		it('should convert 0.00000001 to 1', () => {
 			return expect(convertLSKToBeddows('0.00000001')).to.equal('1');
 		});
-		it('should convert 184467440737.09551615 to 18446744073709551615', () => {
-			return expect(convertLSKToBeddows('184467440737.09551615')).to.equal(
-				'18446744073709551615',
+		it('should convert 100000000 to 10000000000000000', () => {
+			return expect(convertLSKToBeddows('100000000')).to.equal(
+				'10000000000000000',
+			);
+		});
+		it('should convert 99999999.99999999 to 9999999999999999', () => {
+			return expect(convertLSKToBeddows('99999999.99999999')).to.equal(
+				'9999999999999999',
 			);
 		});
 	});

--- a/test/transactions/utils/get_transaction_bytes.js
+++ b/test/transactions/utils/get_transaction_bytes.js
@@ -36,7 +36,7 @@ const defaultSenderSecondPublicKey =
 	'0401c8ac9f29ded9e1e4d5b6b43051cb25b22f27c7b7b35092161e851946f82f';
 // Use (1<<62) + 3 to ensure the highest and the lowest bytes are set and contain different data.
 // This exceeds the safe integer range of JavaScript numbers and thus is expressed as a string.
-const defaultAmount = '4611686018427387907';
+const defaultAmount = '10000000000000000';
 const defaultNoAmount = 0;
 const defaultTimestamp = 141738;
 const defaultTransactionId = '13987348420913138422';
@@ -70,7 +70,7 @@ describe('getTransactionBytes module', () => {
 
 			it('should return Buffer of type 0 (transfer LSK) transaction', () => {
 				const expectedBuffer = Buffer.from(
-					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0300000000000040618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
+					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0000c16ff2862300618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
 					'hex',
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
@@ -81,7 +81,7 @@ describe('getTransactionBytes module', () => {
 			it('should return Buffer of type 0 (transfer LSK) with data', () => {
 				defaultTransaction.asset.data = 'Hello Lisk! Some data in here!...';
 				const expectedBuffer = Buffer.from(
-					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d030000000000004048656c6c6f204c69736b2120536f6d65206461746120696e2068657265212e2e2e618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
+					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0000c16ff286230048656c6c6f204c69736b2120536f6d65206461746120696e2068657265212e2e2e618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
 					'hex',
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
@@ -125,18 +125,10 @@ describe('getTransactionBytes module', () => {
 				).to.throw('Transaction amount is too large.');
 			});
 
-			it('should not throw on type 0 with an amount that is the maximum possible', () => {
-				const amount = bignum.fromBuffer(Buffer.from(new Array(8).fill(255)));
-				defaultTransaction.amount = amount;
-				return expect(
-					getTransactionBytes.bind(null, defaultTransaction),
-				).not.to.throw();
-			});
-
 			it('should return Buffer of transaction with second signature', () => {
 				defaultTransaction.signSignature = defaultSecondSignature;
 				const expectedBuffer = Buffer.from(
-					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0300000000000040618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0ab00c4ad1988bca245d74435660a278bfe6bf2f5efa8bda96d927fabf8b4f6fcfdcb2953f6abacaa119d6880987a55dea0e6354bc8366052b45fa23145522020f',
+					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0000c16ff2862300618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0ab00c4ad1988bca245d74435660a278bfe6bf2f5efa8bda96d927fabf8b4f6fcfdcb2953f6abacaa119d6880987a55dea0e6354bc8366052b45fa23145522020f',
 					'hex',
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
@@ -170,7 +162,7 @@ describe('getTransactionBytes module', () => {
 			it('should return Buffer of type 0 (transfer LSK) with additional properties', () => {
 				defaultTransaction.skip = false;
 				const expectedBuffer = Buffer.from(
-					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0300000000000040618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
+					'00aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0000c16ff2862300618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
 					'hex',
 				);
 				const transactionBytes = getTransactionBytes(defaultTransaction);
@@ -377,7 +369,7 @@ describe('getTransactionBytes module', () => {
 
 			it('should return Buffer of type 6 (dapp inTransfer) transaction', () => {
 				const expectedBuffer = Buffer.from(
-					'06aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae090000000000000000030000000000004031323334323133618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
+					'06aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900000000000000000000c16ff286230031323334323133618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
 					'hex',
 				);
 				const transactionBytes = getTransactionBytes(inTransferTransction);
@@ -406,7 +398,7 @@ describe('getTransactionBytes module', () => {
 
 			it('should return Buffer of type 7 (dapp outTransfer) transaction', () => {
 				const expectedBuffer = Buffer.from(
-					'07aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0300000000000040313233343231333133393837333438343230393133313338343232618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
+					'07aa2902005d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae0900cebcaa8d34153d0000c16ff2862300313233343231333133393837333438343230393133313338343232618a54975212ead93df8c881655c625544bce8ed7ccdfe6f08a42eecfb1adebd051307be5014bb051617baf7815d50f62129e70918190361e5d4dd4796541b0a',
 					'hex',
 				);
 				const transactionBytes = getTransactionBytes(outTransferTransaction);


### PR DESCRIPTION
### What was the problem?

The `MAX_TRANSACTION_AMOUNT` constant did not conform to Core's behaviour.

### How did I fix it?

Reduced it to the value of the initial supply in line with Core's validation check.

### How to test it?

Try creating transactions with amounts larger/smaller than that amount.

### Review checklist

* The PR resolves #763 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
