### PR TITLE
:bug: Fix circular dependency in lisk-cryptography

### DIFF
--- a/packages/lisk-cryptography/src/buffer.js
+++ b/packages/lisk-cryptography/src/buffer.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import bignum from 'browserify-bignum';
+
+export const bigNumberToBuffer = (bignumber, size) =>
+	bignum(bignumber).toBuffer({ size });
+
+export const bufferToBigNumberString = bigNumberBuffer =>
+	bignum.fromBuffer(bigNumberBuffer).toString();
+
+export const bufferToHex = buffer => Buffer.from(buffer).toString('hex');
+
+const hexRegex = /^[0-9a-f]+/i;
+export const hexToBuffer = (hex, argumentName = 'Argument') => {
+	if (typeof hex !== 'string') {
+		throw new TypeError(`${argumentName} must be a string.`);
+	}
+	const matchedHex = (hex.match(hexRegex) || [])[0];
+	if (!matchedHex || matchedHex.length !== hex.length) {
+		throw new TypeError(`${argumentName} must be a valid hex string.`);
+	}
+	if (matchedHex.length % 2 !== 0) {
+		throw new TypeError(
+			`${argumentName} must have a valid length of hex string.`,
+		);
+	}
+	return Buffer.from(matchedHex, 'hex');
+};

--- a/packages/lisk-cryptography/src/convert.js
+++ b/packages/lisk-cryptography/src/convert.js
@@ -13,35 +13,10 @@
  *
  */
 import querystring from 'querystring';
-import bignum from 'browserify-bignum';
 import reverseBuffer from 'buffer-reverse';
 import ed2curve from 'ed2curve';
 import hash from './hash';
-
-export const bigNumberToBuffer = (bignumber, size) =>
-	bignum(bignumber).toBuffer({ size });
-
-export const bufferToBigNumberString = bigNumberBuffer =>
-	bignum.fromBuffer(bigNumberBuffer).toString();
-
-export const bufferToHex = buffer => Buffer.from(buffer).toString('hex');
-
-const hexRegex = /^[0-9a-f]+/i;
-export const hexToBuffer = (hex, argumentName = 'Argument') => {
-	if (typeof hex !== 'string') {
-		throw new TypeError(`${argumentName} must be a string.`);
-	}
-	const matchedHex = (hex.match(hexRegex) || [])[0];
-	if (!matchedHex || matchedHex.length !== hex.length) {
-		throw new TypeError(`${argumentName} must be a valid hex string.`);
-	}
-	if (matchedHex.length % 2 !== 0) {
-		throw new TypeError(
-			`${argumentName} must have a valid length of hex string.`,
-		);
-	}
-	return Buffer.from(matchedHex, 'hex');
-};
+import { bufferToBigNumberString } from './buffer';
 
 export const getFirstEightBytesReversed = publicKeyBytes =>
 	reverseBuffer(Buffer.from(publicKeyBytes).slice(0, 8));

--- a/packages/lisk-cryptography/src/encrypt.js
+++ b/packages/lisk-cryptography/src/encrypt.js
@@ -14,12 +14,8 @@
  */
 import crypto from 'crypto';
 import nacl from 'tweetnacl';
-import {
-	hexToBuffer,
-	bufferToHex,
-	convertPrivateKeyEd2Curve,
-	convertPublicKeyEd2Curve,
-} from './convert';
+import { hexToBuffer, bufferToHex } from './buffer';
+import { convertPrivateKeyEd2Curve, convertPublicKeyEd2Curve } from './convert';
 import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
 
 const PBKDF2_ITERATIONS = 1e6;

--- a/packages/lisk-cryptography/src/hash.js
+++ b/packages/lisk-cryptography/src/hash.js
@@ -13,7 +13,7 @@
  *
  */
 import crypto from 'crypto';
-import { hexToBuffer } from './convert';
+import { hexToBuffer } from './buffer';
 
 const cryptoHashSha256 = data => {
 	const hash = crypto.createHash('sha256');

--- a/packages/lisk-cryptography/src/index.js
+++ b/packages/lisk-cryptography/src/index.js
@@ -12,10 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import * as buffer from './buffer';
 import * as convert from './convert';
 import * as encrypt from './encrypt';
 import hash from './hash';
 import * as keys from './keys';
 import * as sign from './sign';
 
-export default Object.assign({}, convert, encrypt, { hash }, keys, sign);
+export default Object.assign(
+	{},
+	buffer,
+	convert,
+	encrypt,
+	{ hash },
+	keys,
+	sign,
+);

--- a/packages/lisk-cryptography/src/keys.js
+++ b/packages/lisk-cryptography/src/keys.js
@@ -13,7 +13,8 @@
  *
  */
 import nacl from 'tweetnacl';
-import { bufferToHex, getAddressFromPublicKey } from './convert';
+import { bufferToHex } from './buffer';
+import { getAddressFromPublicKey } from './convert';
 import hash from './hash';
 
 export const getPrivateAndPublicKeyBytesFromPassphrase = passphrase => {

--- a/packages/lisk-cryptography/src/sign.js
+++ b/packages/lisk-cryptography/src/sign.js
@@ -16,7 +16,7 @@ import nacl from 'tweetnacl';
 import { encode as encodeVarInt } from 'varuint-bitcoin';
 import { SIGNED_MESSAGE_PREFIX } from 'lisk-constants';
 import hash from './hash';
-import { hexToBuffer, bufferToHex } from './convert';
+import { hexToBuffer, bufferToHex } from './buffer';
 import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
 
 const createHeader = text => `-----${text}-----`;

--- a/packages/lisk-cryptography/test/buffer.js
+++ b/packages/lisk-cryptography/test/buffer.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import {
+	bigNumberToBuffer,
+	bufferToBigNumberString,
+	bufferToHex,
+	hexToBuffer,
+} from '../src/buffer';
+
+describe('buffer', () => {
+	const defaultBuffer = Buffer.from('\xe5\xe4\xf6');
+	const defaultHex = 'c3a5c3a4c3b6';
+
+	describe('#bufferToHex', () => {
+		it('should create a hex string from a Buffer', () => {
+			const hex = bufferToHex(defaultBuffer);
+			return expect(hex).to.be.equal(defaultHex);
+		});
+	});
+
+	describe('#hexToBuffer', () => {
+		it('should create a Buffer from a hex string', () => {
+			const buffer = hexToBuffer(defaultHex);
+			return expect(buffer).to.be.eql(defaultBuffer);
+		});
+
+		it('should throw TypeError with number', () => {
+			return expect(hexToBuffer.bind(null, 123)).to.throw(
+				TypeError,
+				'Argument must be a string.',
+			);
+		});
+
+		it('should throw TypeError with object', () => {
+			return expect(hexToBuffer.bind(null, {})).to.throw(
+				TypeError,
+				'Argument must be a string.',
+			);
+		});
+
+		it('should throw an error for a non-string input with custom argument name', () => {
+			return expect(hexToBuffer.bind(null, {}, 'Custom')).to.throw(
+				'Custom must be a string.',
+			);
+		});
+
+		it('should throw TypeError with non hex string', () => {
+			return expect(hexToBuffer.bind(null, 'yKJj')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
+		});
+
+		it('should throw TypeError with partially correct hex string', () => {
+			return expect(hexToBuffer.bind(null, 'Abxzzzz')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
+		});
+
+		it('should throw TypeError with odd number of string with partially correct hex string', () => {
+			return expect(hexToBuffer.bind(null, 'Abxzzab')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
+		});
+
+		it('should throw TypeError with odd number hex string with invalid hex', () => {
+			return expect(hexToBuffer.bind(null, '123xxxx')).to.throw(
+				TypeError,
+				'Argument must be a valid hex string.',
+			);
+		});
+
+		it('should throw an error for a non-hex string input with custom argument name', () => {
+			return expect(hexToBuffer.bind(null, 'yKJj', 'Custom')).to.throw(
+				'Custom must be a valid hex string.',
+			);
+		});
+
+		it('should throw TypeError with odd-length hex string', () => {
+			return expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a')).to.throw(
+				TypeError,
+				'Argument must have a valid length of hex string.',
+			);
+		});
+
+		it('should throw an error for an odd-length hex string input with custom argument name', () => {
+			return expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a', 'Custom')).to.throw(
+				'Custom must have a valid length of hex string.',
+			);
+		});
+
+		describe('#bigNumberToBuffer', () => {
+			it('should convert a big number to a buffer', () => {
+				const bigNumber = '58191285901858109';
+				const addressSize = 8;
+				const expectedBuffer = Buffer.from('00cebcaa8d34153d', 'hex');
+				return expect(bigNumberToBuffer(bigNumber, addressSize)).to.be.eql(
+					expectedBuffer,
+				);
+			});
+		});
+
+		describe('#bufferToBigNumberString', () => {
+			it('should convert a buffer to a big number', () => {
+				const bigNumber = '58191285901858109';
+				const buffer = Buffer.from('00cebcaa8d34153d', 'hex');
+				return expect(bufferToBigNumberString(buffer)).to.be.equal(bigNumber);
+			});
+		});
+	});
+});

--- a/packages/lisk-cryptography/test/convert.js
+++ b/packages/lisk-cryptography/test/convert.js
@@ -13,15 +13,11 @@
  *
  */
 import {
-	bufferToHex,
-	hexToBuffer,
 	getFirstEightBytesReversed,
 	toAddress,
 	getAddressFromPublicKey,
 	convertPublicKeyEd2Curve,
 	convertPrivateKeyEd2Curve,
-	bigNumberToBuffer,
-	bufferToBigNumberString,
 	stringifyEncryptedPassphrase,
 	parseEncryptedPassphrase,
 } from '../src/convert';
@@ -47,93 +43,10 @@ describe('convert', () => {
 		'hex',
 	);
 	const defaultAddress = '18160565574430594874L';
-	const defaultBuffer = Buffer.from('\xe5\xe4\xf6');
-	const defaultHex = 'c3a5c3a4c3b6';
 	const defaultStringWithMoreThanEightCharacters = '0123456789';
 	const defaultFirstEightCharactersReversed = '76543210';
 	const defaultDataForBuffer = 'Hello!';
 	const defaultAddressFromBuffer = '79600447942433L';
-
-	describe('#bufferToHex', () => {
-		it('should create a hex string from a Buffer', () => {
-			const hex = bufferToHex(defaultBuffer);
-			return expect(hex).to.be.equal(defaultHex);
-		});
-	});
-
-	describe('#hexToBuffer', () => {
-		it('should create a Buffer from a hex string', () => {
-			const buffer = hexToBuffer(defaultHex);
-			return expect(buffer).to.be.eql(defaultBuffer);
-		});
-
-		it('should throw TypeError with number', () => {
-			return expect(hexToBuffer.bind(null, 123)).to.throw(
-				TypeError,
-				'Argument must be a string.',
-			);
-		});
-
-		it('should throw TypeError with object', () => {
-			return expect(hexToBuffer.bind(null, {})).to.throw(
-				TypeError,
-				'Argument must be a string.',
-			);
-		});
-
-		it('should throw an error for a non-string input with custom argument name', () => {
-			return expect(hexToBuffer.bind(null, {}, 'Custom')).to.throw(
-				'Custom must be a string.',
-			);
-		});
-
-		it('should throw TypeError with non hex string', () => {
-			return expect(hexToBuffer.bind(null, 'yKJj')).to.throw(
-				TypeError,
-				'Argument must be a valid hex string.',
-			);
-		});
-
-		it('should throw TypeError with partially correct hex string', () => {
-			return expect(hexToBuffer.bind(null, 'Abxzzzz')).to.throw(
-				TypeError,
-				'Argument must be a valid hex string.',
-			);
-		});
-
-		it('should throw TypeError with odd number of string with partially correct hex string', () => {
-			return expect(hexToBuffer.bind(null, 'Abxzzab')).to.throw(
-				TypeError,
-				'Argument must be a valid hex string.',
-			);
-		});
-
-		it('should throw TypeError with odd number hex string with invalid hex', () => {
-			return expect(hexToBuffer.bind(null, '123xxxx')).to.throw(
-				TypeError,
-				'Argument must be a valid hex string.',
-			);
-		});
-
-		it('should throw an error for a non-hex string input with custom argument name', () => {
-			return expect(hexToBuffer.bind(null, 'yKJj', 'Custom')).to.throw(
-				'Custom must be a valid hex string.',
-			);
-		});
-
-		it('should throw TypeError with odd-length hex string', () => {
-			return expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a')).to.throw(
-				TypeError,
-				'Argument must have a valid length of hex string.',
-			);
-		});
-
-		it('should throw an error for an odd-length hex string input with custom argument name', () => {
-			return expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a', 'Custom')).to.throw(
-				'Custom must have a valid length of hex string.',
-			);
-		});
-	});
 
 	describe('#getFirstEightBytesReversed', () => {
 		it('should get the first eight bytes reversed from a Buffer', () => {
@@ -201,25 +114,6 @@ describe('convert', () => {
 			return expect(
 				defaultPrivateKeyCurve.equals(Buffer.from(curveRepresentation)),
 			).to.be.true;
-		});
-	});
-
-	describe('#bigNumberToBuffer', () => {
-		it('should convert a big number to a buffer', () => {
-			const bigNumber = '58191285901858109';
-			const addressSize = 8;
-			const expectedBuffer = Buffer.from('00cebcaa8d34153d', 'hex');
-			return expect(bigNumberToBuffer(bigNumber, addressSize)).to.be.eql(
-				expectedBuffer,
-			);
-		});
-	});
-
-	describe('#bufferToBigNumberString', () => {
-		it('should convert a buffer to a big number', () => {
-			const bigNumber = '58191285901858109';
-			const buffer = Buffer.from('00cebcaa8d34153d', 'hex');
-			return expect(bufferToBigNumberString(buffer)).to.be.equal(bigNumber);
 		});
 	});
 

--- a/packages/lisk-cryptography/test/keys.js
+++ b/packages/lisk-cryptography/test/keys.js
@@ -20,7 +20,7 @@ import {
 	getAddressFromPassphrase,
 } from '../src/keys';
 // Require is used for stubbing
-const convert = require('../src/convert');
+const buffer = require('../src/buffer');
 const hash = require('../src/hash');
 
 describe('keys', () => {
@@ -40,7 +40,7 @@ describe('keys', () => {
 	let bufferToHexStub;
 
 	beforeEach(() => {
-		bufferToHexStub = sandbox.stub(convert, 'bufferToHex');
+		bufferToHexStub = sandbox.stub(buffer, 'bufferToHex');
 		bufferToHexStub
 			.withArgs(Buffer.from(defaultPrivateKey, 'hex'))
 			.returns(defaultPrivateKey);


### PR DESCRIPTION
### What was the problem?

Circular dependency in lisk-cryptography, specifically the "hexToBuffer" function in convert module being used in hash module.

### How did I fix it?

Separated buffer specific logic into a new buffer module along with the corresponding tests.

### How to test it?

Install, build, lint, test etc.

### Review checklist
* The PR resolves #775
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the commit guidelines
* Documentation has been added/updated
