### PR TITLE
:recycle: Update MAX_TRANSACTION_AMOUNT - Closes #779

### DIFF
--- a/packages/lisk-constants/src/index.js
+++ b/packages/lisk-constants/src/index.js
@@ -22,8 +22,8 @@ const MAX_EIGHT_BYTE_NUMBER = '18446744073709551615';
 
 export const MAX_ADDRESS_NUMBER = MAX_EIGHT_BYTE_NUMBER;
 export const MAX_TRANSACTION_ID = MAX_EIGHT_BYTE_NUMBER;
-// Largest possible amount. Equal to the initial supply.
-export const MAX_TRANSACTION_AMOUNT = '10000000000000000';
+// Largest possible amount. Maximum value for PostgreSQL bigint.
+export const MAX_TRANSACTION_AMOUNT = '9223372036854775807';
 
 export const SIGNED_MESSAGE_PREFIX = 'Lisk Signed Message:\n';
 


### PR DESCRIPTION
### What was the problem?

We needed to update `MAX_TRANSACTION_AMOUNT`.

### How did I fix it?

Updated it to the PostgreSQL bigint maximum.

### How to test it?

Try to create/validate a transaction with an amount that will be rejected by a node.

### Review checklist

* The PR resolves #779 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
