### PR TITLE
Upgrade lerna and lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
 	},
 	"devDependencies": {
 		"husky": "0.14.3",
-		"lerna": "3.2.1",
-		"lint-staged": "7.2.2",
+		"lerna": "3.4.1",
+		"lint-staged": "7.3.0",
 		"prettier": "1.14.2"
 	}
 }


### PR DESCRIPTION
### What was the problem?
Lerna was not running `link` occasionally 

### How did I fix it?
Upgrading lerna version seems to fix the issue

### How to test it?
```
npm run clean
npm run clean:node_modules
npm install
npm run build
```

### Review checklist

* The PR resolves #796 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
