### PR TITLE
789 - Add benchmark for nacl libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 		"@lerna/batch-packages": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.1.2.tgz",
-			"integrity": "sha1-dLUxKgGokWIEy8cSN/++kxRLmd8=",
+			"integrity": "sha512-HAkpptrYeUVlBYbLScXgeCgk6BsNVXxDd53HVWgzzTWpXV4MHpbpeKrByyt7viXlNhW0w73jJbipb/QlFsHIhQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/package-graph": "^3.1.2",
@@ -80,7 +80,7 @@
 		"@lerna/check-working-tree": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.3.0.tgz",
-			"integrity": "sha1-IRjzAfKMy1MIEuWyejQbHms8hOI=",
+			"integrity": "sha512-oeEP1dNhiiKUaO0pmcIi73YXJpaD0n5JczNctvVNZ8fGZmrALZtEnmC28o6Z7JgQaqq5nd2kO7xbnjoitrC51g==",
 			"dev": true,
 			"requires": {
 				"@lerna/describe-ref": "^3.3.0",
@@ -90,7 +90,7 @@
 		"@lerna/child-process": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.3.0.tgz",
-			"integrity": "sha1-cRhKdjEFtsjs4n9D8WZJjZD+aA8=",
+			"integrity": "sha512-q2d/OPlNX/cBXB6Iz1932RFzOmOHq6ZzPjqebkINNaTojHWuuRpvJJY4Uz3NGpJ3kEtPDvBemkZqUBTSO5wb1g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.1",
@@ -116,7 +116,7 @@
 		"@lerna/cli": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.2.0.tgz",
-			"integrity": "sha1-PtJby8C48IeLxqEC7gKW8BR2z98=",
+			"integrity": "sha512-JdbLyTxHqxUlrkI+Ke+ltXbtyA+MPu9zR6kg/n8Fl6uaez/2fZWtReXzYi8MgLxfUFa7+1OHWJv4eAMZlByJ+Q==",
 			"dev": true,
 			"requires": {
 				"@lerna/global-options": "^3.1.3",
@@ -141,7 +141,7 @@
 		"@lerna/command": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.3.0.tgz",
-			"integrity": "sha1-6BxHFqZ2sC2+nT9UjV9FtLoywlo=",
+			"integrity": "sha512-NTOkLEKlWcBLHSvUr9tzVpV7RJ4GROLeOuZ6RfztGOW/31JPSwVVBD2kPifEXNZunldOx5GVWukR+7+NpAWhsg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -200,7 +200,7 @@
 		"@lerna/create-symlink": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.3.0.tgz",
-			"integrity": "sha1-kd4A/VdgGLpCUfDGpbS392jyKoI=",
+			"integrity": "sha512-0lb88Nnq1c/GG+fwybuReOnw3+ah4dB81PuWwWwuqUNPE0n50qUf/M/7FfSb5JEh/93fcdbZI0La8t3iysNW1w==",
 			"dev": true,
 			"requires": {
 				"cmd-shim": "^2.0.2",
@@ -211,7 +211,7 @@
 		"@lerna/describe-ref": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.3.0.tgz",
-			"integrity": "sha1-03OttTDVQoq5HjA8y/z1Gpg3Sjo=",
+			"integrity": "sha512-4t7M4OupnYMSPNLrLUau8qkS+dgLEi4w+DkRkV0+A+KNYga1W0jVgNLPIIsxta7OHfodPkCNAqZCzNCw/dmAwA==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -221,7 +221,7 @@
 		"@lerna/diff": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.3.0.tgz",
-			"integrity": "sha1-yBMKX1CLR/rV/sgUBEmLw6zfnLU=",
+			"integrity": "sha512-sIoMjsm3NVxvmt6ofx8Uu/2fxgldQqLl0zmC9X1xW00j831o5hBffx1EoKj9CnmaEvoSP6j/KFjxy2RWjebCIg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -258,7 +258,7 @@
 		"@lerna/filter-packages": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.0.0.tgz",
-			"integrity": "sha1-XrJa0WEPPiq4RRM9H419QDFOg48=",
+			"integrity": "sha512-zwbY1J4uRjWRZ/FgYbtVkq7I3Nduwsg2V2HwLKSzwV2vPglfGqgovYOVkND6/xqe2BHwDX4IyA2+e7OJmLaLSA==",
 			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "^3.0.0",
@@ -269,7 +269,7 @@
 		"@lerna/get-npm-exec-opts": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0.tgz",
-			"integrity": "sha1-j8eGbo2Omi8tw4Uoe6MutE3oves=",
+			"integrity": "sha512-arcYUm+4xS8J3Palhl+5rRJXnZnFHsLFKHBxznkPIxjwGQeAEw7df38uHdVjEQ+HNeFmHnBgSqfbxl1VIw5DHg==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
@@ -278,13 +278,13 @@
 		"@lerna/global-options": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.1.3.tgz",
-			"integrity": "sha1-z4XiRlWpHQTU78moDB+D/HaNCK4=",
+			"integrity": "sha512-LVeZU/Zgc0XkHdGMRYn+EmHfDmmYNwYRv3ta59iCVFXLVp7FRFWF7oB1ss/WRa9x/pYU0o6L8as/5DomLUGASA==",
 			"dev": true
 		},
 		"@lerna/has-npm-version": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.3.0.tgz",
-			"integrity": "sha1-inPCxDeg4eaKGcy9DdPAFNTTkTU=",
+			"integrity": "sha512-GX7omRep1eBRZHgjZLRw3MpBJSdA5gPZFz95P7rxhpvsiG384Tdrr/cKFMhm0A09yq27Tk/nuYTaZIj7HsVE6g==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -309,7 +309,7 @@
 		"@lerna/init": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.3.0.tgz",
-			"integrity": "sha1-mY80l9o9iRhnxZO4CLbbS4/EzLk=",
+			"integrity": "sha512-HvgRLkIG6nDIeAO6ix5sUVIVV+W9UMk2rSSmFT66CDOefRi7S028amiyYnFUK1QkIAaUbVUyOnYaErtbJwICuw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -322,7 +322,7 @@
 		"@lerna/link": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.3.0.tgz",
-			"integrity": "sha1-wMBf9S0PDGWfzyIWJ+381Y5Helw=",
+			"integrity": "sha512-8CeXzGL7okrsVXsy2sHXI2KuBaczw3cblAnA2+FJPUqSKMPNbUTRzeU3bOlCjYtK0LbxC4ngENJTL3jJ8RaYQQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/command": "^3.3.0",
@@ -347,7 +347,7 @@
 		"@lerna/listable": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.0.0.tgz",
-			"integrity": "sha1-JyCbE4LIer28lkIg51wkfYA9QZk=",
+			"integrity": "sha512-HX/9hyx1HLg2kpiKXIUc1EimlkK1T58aKQ7ovO7rQdTx9ForpefoMzyLnHE1n4XrUtEszcSWJIICJ/F898M6Ag==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.1",
@@ -357,7 +357,7 @@
 		"@lerna/log-packed": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.0.4.tgz",
-			"integrity": "sha1-bR9s5cpouZcfKifw7PPFBoS+F0o=",
+			"integrity": "sha512-vVQHgMagE2wnbxhNY9nFkdu+Cx2TsyWalkJfkxbNzmo6gOCrDsxCBDj9vTEV8Q+4aWx0C0Bsc0sB2Eb8y/+ofA==",
 			"dev": true,
 			"requires": {
 				"byte-size": "^4.0.3",
@@ -379,7 +379,7 @@
 		"@lerna/npm-dist-tag": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.3.0.tgz",
-			"integrity": "sha1-4cWrZ2dCFtkBJmoWhGshzIH/av0=",
+			"integrity": "sha512-EtZJXzh3w5tqXEev+EBBPrWKWWn0WgJfxm4FihfS9VgyaAW8udIVZHGkIQ3f+tBtupcAzA9Q8cQNUkGF2efwmA==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -390,7 +390,7 @@
 		"@lerna/npm-install": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.3.0.tgz",
-			"integrity": "sha1-FtAP/WaNEbI4azrGi9rCz4Mg5TM=",
+			"integrity": "sha512-WoVvKdS8ltROTGSNQwo6NDq0YKnjwhvTG4li1okcN/eHKOS3tL9bxbgPx7No0wOq5DKBpdeS9KhAfee6LFAZ5g==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -420,7 +420,7 @@
 		"@lerna/npm-run-script": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.3.0.tgz",
-			"integrity": "sha1-PHlgHCfGcSEVWyDgOb5TEwIX23I=",
+			"integrity": "sha512-YqDguWZzp4jIomaE4aWMUP7MIAJAFvRAf6ziQLpqwoQskfWLqK5mW0CcszT1oLjhfb3cY3MMfSTFaqwbdKmICg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -431,7 +431,7 @@
 		"@lerna/output": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.0.0.tgz",
-			"integrity": "sha1-TtSjDtLzEQRrcUs4QKCQmQujzjU=",
+			"integrity": "sha512-EFxnSbO0zDEVKkTKpoCUAFcZjc3gn3DwPlyTDxbeqPU7neCfxP4rA4+0a6pcOfTlRS5kLBRMx79F2TRCaMM3DA==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
@@ -440,7 +440,7 @@
 		"@lerna/package": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.0.0.tgz",
-			"integrity": "sha1-FK/Jpssff3sjwdfHqoG9rH1EwOU=",
+			"integrity": "sha512-djzEJxzn212wS8d9znBnlXkeRlPL7GqeAYBykAmsuq51YGvaQK67Umh5ejdO0uxexF/4r7yRwgrlRHpQs8Rfqg==",
 			"dev": true,
 			"requires": {
 				"npm-package-arg": "^6.0.0",
@@ -450,7 +450,7 @@
 		"@lerna/package-graph": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.1.2.tgz",
-			"integrity": "sha1-twKYo6jILhIJDaMyM78kIiOjjyA=",
+			"integrity": "sha512-9wIWb49I1IJmyjPdEVZQ13IAi9biGfH/OZHOC04U2zXGA0GLiY+B3CAx6FQvqkZ8xEGfqzmXnv3LvZ0bQfc1aQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "^3.0.0",
@@ -461,7 +461,7 @@
 		"@lerna/project": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.0.0.tgz",
-			"integrity": "sha1-QyDSorQIDKvPlRYdnEhHUhfYpUU=",
+			"integrity": "sha512-XhDFVfqj79jG2Speggd15RpYaE8uiR25UKcQBDmumbmqvTS7xf2cvl2pq2UTvDafaJ0YwFF3xkxQZeZnFMwdkw==",
 			"dev": true,
 			"requires": {
 				"@lerna/package": "^3.0.0",
@@ -525,7 +525,7 @@
 		"@lerna/resolve-symlink": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.3.0.tgz",
-			"integrity": "sha1-xdmaYMsX4uqQs1IaC6RFR40ZSkQ=",
+			"integrity": "sha512-KmoPDcFJ2aOK2inYHbrsiO9SodedUj0L1JDvDgirVNIjMUaQe2Q6Vi4Gh+VCJcyB27JtfHioV9R2NxU72Pk2hg==",
 			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
@@ -536,7 +536,7 @@
 		"@lerna/rimraf-dir": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.3.0.tgz",
-			"integrity": "sha1-aH6bs2aKnlQOKBMCpS2aVzhg9ds=",
+			"integrity": "sha512-vSqOcZ4kZduiSprbt+y40qziyN3VKYh+ygiCdnbBbsaxpdKB6CfrSMUtrLhVFrqUfBHIZRzHIzgjTdtQex1KLw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "^3.3.0",
@@ -575,7 +575,7 @@
 		"@lerna/run-parallel-batches": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0.tgz",
-			"integrity": "sha1-RocEk0CEx0mR0xJNgGB4V9TfqEA=",
+			"integrity": "sha512-Mj1ravlXF7AkkewKd9YFq9BtVrsStNrvVLedD/b2wIVbNqcxp8lS68vehXVOzoL/VWNEDotvqCQtyDBilCodGw==",
 			"dev": true,
 			"requires": {
 				"p-map": "^1.2.0",
@@ -585,7 +585,7 @@
 		"@lerna/symlink-binary": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.3.0.tgz",
-			"integrity": "sha1-mepXCyG6q9YeyrJ1gu6x17LF+c8=",
+			"integrity": "sha512-zRo6CimhvH/VJqCFl9T4IC6syjpWyQIxEfO2sBhrapEcfwjtwbhoGgKwucsvt4rIpFazCw63jQ/AXMT27KUIHg==",
 			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "^3.3.0",
@@ -598,7 +598,7 @@
 		"@lerna/symlink-dependencies": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.3.0.tgz",
-			"integrity": "sha1-E7yu0+N5hqsBsTSYpFnH9gk5fcM=",
+			"integrity": "sha512-IRngSNCmuD5uBKVv23tHMvr7Mplti0lKHilFKcvhbvhAfu6m/Vclxhkfs/uLyHzG+DeRpl/9o86SQET3h4XDhg==",
 			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "^3.3.0",
@@ -613,7 +613,7 @@
 		"@lerna/validation-error": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.0.0.tgz",
-			"integrity": "sha1-on6QBRw7pxmV4qgApD2UrQSz4/Q=",
+			"integrity": "sha512-5wjkd2PszV0kWvH+EOKZJWlHEqCTTKrWsvfHnHhcUaKBe/NagPZFWs+0xlsDPZ3DJt5FNfbAPAnEBQ05zLirFA==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
@@ -651,7 +651,7 @@
 		"@lerna/write-log-file": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.0.0.tgz",
-			"integrity": "sha1-L5X+6AxoIf4e5sz4Fz0rQHneu9I=",
+			"integrity": "sha512-SfbPp29lMeEVOb/M16lJwn4nnx5y+TwCdd7Uom9umd7KcZP0NOvpnX0PHehdonl7TyHZ1Xx2maklYuCLbQrd/A==",
 			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2",
@@ -661,7 +661,7 @@
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-			"integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
 			"dev": true,
 			"requires": {
 				"call-me-maybe": "^1.0.1",
@@ -671,7 +671,7 @@
 		"@nodelib/fs.stat": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
-			"integrity": "sha1-VMWpZEYr49TXivYxNjwY1vqRrCY=",
+			"integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==",
 			"dev": true
 		},
 		"@samverschueren/stream-to-observable": {
@@ -696,13 +696,13 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
 		"agent-base": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-			"integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
 			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
@@ -711,7 +711,7 @@
 		"agentkeepalive": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.1.tgz",
-			"integrity": "sha1-Trp1zyrSWPwJ79UGzbjYwpcdNaQ=",
+			"integrity": "sha512-Cte/sTY9/XcygXjJ0q58v//SnEQ7ViWExKyJpLJlLqomDbQyMLh6Is4KuWJ/wmxzhiwkGRple7Gqv1zf6Syz5w==",
 			"dev": true,
 			"requires": {
 				"humanize-ms": "^1.2.1"
@@ -744,7 +744,7 @@
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
@@ -759,13 +759,13 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
+			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
@@ -775,7 +775,7 @@
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
@@ -790,7 +790,7 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
 			"dev": true
 		},
 		"arr-union": {
@@ -853,7 +853,7 @@
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
@@ -889,7 +889,7 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
 		"aws-sign2": {
@@ -901,7 +901,7 @@
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
 		},
 		"babel-code-frame": {
@@ -951,7 +951,7 @@
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
@@ -975,7 +975,7 @@
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -984,7 +984,7 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -993,7 +993,7 @@
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -1031,7 +1031,7 @@
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -1041,7 +1041,7 @@
 		"braces": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
@@ -1070,7 +1070,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
 		"builtin-modules": {
@@ -1094,13 +1094,13 @@
 		"byte-size": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.3.tgz",
-			"integrity": "sha1-t8CV78aOrfgphfzNmi30OnT6LM0=",
+			"integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg==",
 			"dev": true
 		},
 		"cacache": {
 			"version": "11.2.0",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
-			"integrity": "sha1-YXvcCwKESvVjEOQRwIeJQdVzmWU=",
+			"integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.1",
@@ -1122,7 +1122,7 @@
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
@@ -1168,7 +1168,7 @@
 		"chalk": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
@@ -1197,7 +1197,7 @@
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
@@ -1245,7 +1245,7 @@
 		"cliui": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1",
@@ -1268,7 +1268,7 @@
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
@@ -1327,7 +1327,7 @@
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
@@ -1350,9 +1350,9 @@
 			}
 		},
 		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
@@ -1361,7 +1361,7 @@
 		"commander": {
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
 			"dev": true
 		},
 		"compare-func": {
@@ -1400,7 +1400,7 @@
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -1458,7 +1458,7 @@
 			"dependencies": {
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
@@ -1585,7 +1585,7 @@
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-			"integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
@@ -1611,7 +1611,7 @@
 		"cosmiconfig": {
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
-			"integrity": "sha1-3KbPaAoL0DWJr/aEcAhYyBq+6zk=",
+			"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
 			"dev": true,
 			"requires": {
 				"is-directory": "^0.3.1",
@@ -1622,7 +1622,7 @@
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
 				"nice-try": "^1.0.4",
@@ -1674,13 +1674,13 @@
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
 			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
@@ -1740,7 +1740,7 @@
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
@@ -1750,7 +1750,7 @@
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -1759,7 +1759,7 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -1768,7 +1768,7 @@
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -1815,7 +1815,7 @@
 		"dir-glob": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-			"integrity": "sha1-CyBdK2rvmCOMooZZioIE0p0KADQ=",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
@@ -1825,7 +1825,7 @@
 		"dot-prop": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-			"integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
@@ -1840,7 +1840,7 @@
 		"duplexify": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-			"integrity": "sha1-WSkD9dgLONA3IgVBJk1poZj7NBA=",
+			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
@@ -1878,7 +1878,7 @@
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -1893,7 +1893,7 @@
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
@@ -1923,7 +1923,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
 		"esutils": {
@@ -1935,7 +1935,7 @@
 		"execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-			"integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.0",
@@ -1991,7 +1991,7 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
 		},
 		"extend-shallow": {
@@ -2007,7 +2007,7 @@
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
@@ -2029,7 +2029,7 @@
 		"extglob": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-			"integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
@@ -2063,7 +2063,7 @@
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2072,7 +2072,7 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2081,7 +2081,7 @@
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -2137,7 +2137,7 @@
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 			"dev": true
 		},
 		"figures": {
@@ -2190,7 +2190,7 @@
 		"flush-write-stream": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha1-xdWG7zivYJdlC0m8QbVfq7GfNb0=",
+			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
@@ -2218,6 +2218,17 @@
 				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
 				"mime-types": "^2.1.12"
+			},
+			"dependencies": {
+				"combined-stream": {
+					"version": "1.0.6",
+					"resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+					"dev": true,
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				}
 			}
 		},
 		"fragment-cache": {
@@ -2253,7 +2264,7 @@
 		"fs-minipass": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
+			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
@@ -2314,7 +2325,7 @@
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
 			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
@@ -2501,7 +2512,7 @@
 		"glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -2552,7 +2563,7 @@
 		"handlebars": {
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-			"integrity": "sha1-LBXIqW1G2l4mZwBRi6jLjZGdW8U=",
+			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
 			"dev": true,
 			"requires": {
 				"async": "^2.5.0",
@@ -2564,7 +2575,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
 			}
@@ -2647,13 +2658,13 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha1-ObDhat2bYFvwqe89nar0hDtMrNI=",
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 			"dev": true
 		},
 		"http-proxy-agent": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-			"integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
 			"dev": true,
 			"requires": {
 				"agent-base": "4",
@@ -2663,7 +2674,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2685,7 +2696,7 @@
 		"https-proxy-agent": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.1.0",
@@ -2753,7 +2764,7 @@
 		"ignore-walk": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-			"integrity": "sha1-qD5i59JyrA47VRqqgoMaGbafgvg=",
+			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.4"
@@ -2762,7 +2773,7 @@
 		"import-local": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha1-Xk/9wD9P5sAJxnKb6yljHC+CJ7w=",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
@@ -2800,13 +2811,13 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
 		"init-package-json": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
-			"integrity": "sha1-Rf/i9hCoyhNPK9HbVjeyNQcPbL4=",
+			"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
@@ -2851,15 +2862,6 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
-				},
-				"rxjs": {
-					"version": "6.3.3",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-					"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.9.0"
-					}
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -2923,7 +2925,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
 		"is-builtin-module": {
@@ -2967,7 +2969,7 @@
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
@@ -2978,7 +2980,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
 					"dev": true
 				}
 			}
@@ -3050,7 +3052,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -3072,7 +3074,7 @@
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
@@ -3126,7 +3128,7 @@
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
 		},
 		"isarray": {
@@ -3180,7 +3182,7 @@
 		"js-yaml": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
+			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -3197,7 +3199,7 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
 		"json-schema": {
@@ -3248,7 +3250,7 @@
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 			"dev": true
 		},
 		"lcid": {
@@ -3581,9 +3583,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
 		"lodash._reinterpolate": {
@@ -3682,7 +3684,7 @@
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
@@ -3692,7 +3694,7 @@
 		"make-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
@@ -3701,7 +3703,7 @@
 		"make-fetch-happen": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
-			"integrity": "sha1-FBSXy4ePJDupMTbIPYq6EsIWwIM=",
+			"integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
 			"dev": true,
 			"requires": {
 				"agentkeepalive": "^3.4.1",
@@ -3761,7 +3763,7 @@
 		"meow": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-			"integrity": "sha1-1IWY9vSxRy81v2MXqVlFrONH+XU=",
+			"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 			"dev": true,
 			"requires": {
 				"camelcase-keys": "^4.0.0",
@@ -3790,13 +3792,13 @@
 		"merge2": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-			"integrity": "sha1-AyEuPajYbE2FI869YxgZNBT5TjQ=",
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
 			"dev": true
 		},
 		"micromatch": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -3817,13 +3819,13 @@
 		"mime-db": {
 			"version": "1.36.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-			"integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c=",
+			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
 			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.20",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-			"integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
 			"dev": true,
 			"requires": {
 				"mime-db": "~1.36.0"
@@ -3832,13 +3834,13 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
@@ -3846,14 +3848,14 @@
 		},
 		"minimist": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
 		"minimist-options": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-			"integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
+			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
@@ -3863,7 +3865,7 @@
 		"minipass": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
-			"integrity": "sha1-R2jXYF7WGU1tV2FpueEu9x6dmVc=",
+			"integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
@@ -3881,7 +3883,7 @@
 		"minizlib": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-			"integrity": "sha1-EeE2WM5GvDpwomeqxYNZ0eDCnOs=",
+			"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
 			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
@@ -3890,7 +3892,7 @@
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-			"integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
@@ -3908,7 +3910,7 @@
 		"mixin-deep": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -3918,7 +3920,7 @@
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
@@ -3928,7 +3930,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -3937,7 +3939,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				}
@@ -3946,7 +3948,7 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha1-s5OfpgVUZHTj4+PGPWS9Q7TuYCI=",
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
 			"dev": true
 		},
 		"move-concurrently": {
@@ -3990,7 +3992,7 @@
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-			"integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -4009,13 +4011,13 @@
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
 		"node-fetch-npm": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-			"integrity": "sha1-cljJBGGC3KNFtCCO2pGNrzNpf/c=",
+			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
 			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
@@ -4026,7 +4028,7 @@
 		"node-gyp": {
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-			"integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
+			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"dev": true,
 			"requires": {
 				"fstream": "^1.0.0",
@@ -4063,7 +4065,7 @@
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
@@ -4081,13 +4083,13 @@
 		"npm-bundled": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-			"integrity": "sha1-PBcyt7qTazoQMlrvYWRnwMy8yXk=",
+			"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
 			"dev": true
 		},
 		"npm-lifecycle": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz",
-			"integrity": "sha1-Htou7bgtuSnjoMUDQasKrRQO1Wk=",
+			"integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
 			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
@@ -4103,7 +4105,7 @@
 		"npm-package-arg": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
-			"integrity": "sha1-Fa4eJ1ilAn77TCUFVLhac323/ME=",
+			"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.6.0",
@@ -4113,9 +4115,9 @@
 			}
 		},
 		"npm-packlist": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
-			"integrity": "sha1-hOjGg8vnhn00sdNX2JPOKeKKAt4=",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
+			"integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
 			"dev": true,
 			"requires": {
 				"ignore-walk": "^3.0.1",
@@ -4134,7 +4136,7 @@
 		"npm-pick-manifest": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
-			"integrity": "sha1-3Dgb3WcMNdgWVeHVqUqj3U2H/OU=",
+			"integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
 			"dev": true,
 			"requires": {
 				"npm-package-arg": "^6.0.0",
@@ -4144,7 +4146,7 @@
 		"npm-registry-fetch": {
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.8.0.tgz",
-			"integrity": "sha1-qn2afJKv+U9I26CYS970vRMciMw=",
+			"integrity": "sha512-hrw8UMD+Nob3Kl3h8Z/YjmKamb1gf7D1ZZch2otrIXM3uFLB5vjEY6DhMlq80z/zZet6eETLbOXcuQudCB3Zpw==",
 			"dev": true,
 			"requires": {
 				"JSONStream": "^1.3.4",
@@ -4178,7 +4180,7 @@
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
@@ -4284,7 +4286,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.0.10",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
 					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
 					"dev": true
 				}
@@ -4339,7 +4341,7 @@
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
@@ -4385,7 +4387,7 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
 			"dev": true
 		},
 		"p-map-series": {
@@ -4427,7 +4429,7 @@
 		"pacote": {
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.1.0.tgz",
-			"integrity": "sha1-WYEIWbvXKYTcsmcmklk3XTLzkeU=",
+			"integrity": "sha512-AFXaSWhOtQf3jHqEvg+ZYH/dfT8TKq6TKspJ4qEFwVVuh5aGvMIk6SNF8vqfzz+cBceDIs9drOcpBbrPai7i+g==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.1",
@@ -4468,7 +4470,7 @@
 				"tar": {
 					"version": "4.4.6",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
-					"integrity": "sha1-YxEPCcALTmCsi8/hvzyGYCNfvJs=",
+					"integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -4644,7 +4646,7 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true
 		},
 		"promise-inflight": {
@@ -4681,7 +4683,7 @@
 		"protoduck": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.0.tgz",
-			"integrity": "sha1-dSFF5r4K2DTLJXFvZwpxPIYNznA=",
+			"integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
 			"dev": true,
 			"requires": {
 				"genfun": "^4.0.1"
@@ -4696,13 +4698,13 @@
 		"psl": {
 			"version": "1.1.29",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha1-YPWA02AXC7cip5fMcEQR5tqFDGc=",
+			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
 			"dev": true
 		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
@@ -4712,7 +4714,7 @@
 		"pumpify": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-			"integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
@@ -4723,7 +4725,7 @@
 				"pump": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -4747,7 +4749,7 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
 		"quick-lru": {
@@ -4777,7 +4779,7 @@
 		"read-package-json": {
 			"version": "2.0.13",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
-			"integrity": "sha1-LoLr2fYTuqbS6+Oqcs7+P2jkH0o=",
+			"integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
@@ -4790,7 +4792,7 @@
 		"read-package-tree": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
-			"integrity": "sha1-Yhixh9b6yCKJzkOHu7r47vU2rWM=",
+			"integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
 			"dev": true,
 			"requires": {
 				"debuglog": "^1.0.1",
@@ -4833,7 +4835,7 @@
 				},
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
@@ -4903,8 +4905,8 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -4941,7 +4943,7 @@
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
@@ -4951,7 +4953,7 @@
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
 			"dev": true
 		},
 		"repeat-string": {
@@ -5060,7 +5062,7 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
 		"retry": {
@@ -5072,7 +5074,7 @@
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
@@ -5108,7 +5110,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
 		"safe-regex": {
@@ -5123,13 +5125,13 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
 		"semver": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-			"integrity": "sha1-ff3YgUvbfKvHvg+x1zTPtmyUBHc=",
+			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
 			"dev": true
 		},
 		"semver-compare": {
@@ -5147,7 +5149,7 @@
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -5209,13 +5211,13 @@
 		"smart-buffer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
-			"integrity": "sha1-B+ocqNTbJOtMrIZTfX0YmVIhrOM=",
+			"integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==",
 			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
@@ -5251,7 +5253,7 @@
 		"snapdragon-node": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
@@ -5271,7 +5273,7 @@
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -5280,7 +5282,7 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -5289,7 +5291,7 @@
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -5302,7 +5304,7 @@
 		"snapdragon-util": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
@@ -5322,7 +5324,7 @@
 		"socks": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.2.1.tgz",
-			"integrity": "sha1-aK1nizZC+8XZnGTBZbxWHqsCFfk=",
+			"integrity": "sha512-0GabKw7n9mI46vcNrVfs0o6XzWzjVa3h6GaSo2UPxtWAROXUWavfJWh1M4PR5tnE0dcnQXZIDFP4yrAysLze/w==",
 			"dev": true,
 			"requires": {
 				"ip": "^1.1.5",
@@ -5332,7 +5334,7 @@
 		"socks-proxy-agent": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
-			"integrity": "sha1-WTa/i3B6mTB5xvN9sgkYIb/6ZHM=",
+			"integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
 			"dev": true,
 			"requires": {
 				"agent-base": "~4.2.0",
@@ -5357,7 +5359,7 @@
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
@@ -5392,7 +5394,7 @@
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -5408,7 +5410,7 @@
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"dev": true,
 			"requires": {
 				"through": "2"
@@ -5417,7 +5419,7 @@
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
@@ -5426,7 +5428,7 @@
 		"split2": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-			"integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
+			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
@@ -5458,7 +5460,7 @@
 		"ssri": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1"
@@ -5494,7 +5496,7 @@
 		"stream-each": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-			"integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
@@ -5527,7 +5529,7 @@
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -5574,7 +5576,7 @@
 		"strong-log-transformer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.0.0.tgz",
-			"integrity": "sha1-+m2OCp5is8Fow8rVrl0A3Je6Jsw=",
+			"integrity": "sha512-FQmNqAXJgOX8ygOcvPLlGWBNT41mvNJ9ALoYf0GTwVt9t30mGTqpmp/oJx5gLcu52DXK10kS7dVWhx8aPXDTlg==",
 			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
@@ -5586,7 +5588,7 @@
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
@@ -5683,7 +5685,7 @@
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
@@ -5724,7 +5726,7 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 					"dev": true
 				}
 			}
@@ -5744,7 +5746,7 @@
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
 			"dev": true
 		},
 		"tslint": {
@@ -5904,7 +5906,7 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
 		"unset-value": {
@@ -5956,7 +5958,7 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
 		"util-deprecate": {
@@ -5968,7 +5970,7 @@
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -6013,7 +6015,7 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
 			"dev": true
 		},
 		"whatwg-url": {
@@ -6030,7 +6032,7 @@
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
@@ -6045,7 +6047,7 @@
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
@@ -6076,7 +6078,7 @@
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
@@ -6101,7 +6103,7 @@
 		"write-pkg": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
-			"integrity": "sha1-DheP6Xgg04mokovHlTXb5ows/yE=",
+			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
 			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
@@ -6111,7 +6113,7 @@
 		"xregexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-			"integrity": "sha1-5pgYneSd0qGMxWh7BeF8jkOUMCA=",
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
 			"dev": true
 		},
 		"xtend": {
@@ -6123,7 +6125,7 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
 		},
 		"yallist": {
@@ -6240,7 +6242,7 @@
 		"yargs-parser": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-			"integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
+			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"

--- a/packages/lisk-cryptography/README.md
+++ b/packages/lisk-cryptography/README.md
@@ -24,20 +24,14 @@ $ npx babel-node ./benchmark/nacl
 
 Benchmark results for nacl functions:
 
-| Function            | Results                                                         | Winner |      
-| ------------------- | ----------------------------------------------------------------| ------ |       
-| fast.box            | fast.box x 23,982 ops/sec ±0.59%                                |   ✓    |
-| slow.box            | slow.box x 771 ops/sec ±0.44%                                   |        |
-| fast.openBox        | fast.openBox x 24,247 ops/sec ±0.42%                            |   ✓    |
-| slow.openBox        | slow.openBox x 770 ops/sec ±0.69%                               |        |
-| fast.signDetached   | fast.signDetached x 46,402 ops/sec ±0.32%                       |   ✓    |
-| slow.signDetached   | slow.signDetached x 236 ops/sec ±1.63%                          |        |
-| fast.verifyDetached | fast.verifyDetached x 17,153 ops/sec ±0.19%                     |   ✓    |
-| slow.verifyDetached | slow.verifyDetached x 122 ops/sec ±0.61%                        |        |
-| fast.getRandomBytes | fast.getRandomBytes x 207,866 ops/sec ±0.23%                    |        |
-| slow.getRandomBytes | slow.getRandomBytes x 299,959 ops/sec ±0.39%                    |   ✓    |
-| fast.getKeyPair     | fast.getKeyPair x 38,815 ops/sec ±0.16%                         |   ✓    |
-| slow.getKeyPair     | slow.getKeyPair x 242 ops/sec ±0.62%                            |        |
+| Function            | Fast                     | Slow                     | Winner |      
+| :-----------------: | :-----------------------:|:-----------------------: | :----: |       
+| box                 | x 23,982 ops/sec ±0.59%  | x 771 ops/sec ±0.44%     |  Fast  |
+| openBox             | x 24,247 ops/sec ±0.42%  | x 770 ops/sec ±0.69%     |  Fast  |
+| signDetached        | x 46,402 ops/sec ±0.32%  | x 236 ops/sec ±1.63%     |  Fast  |
+| verifyDetached      | x 17,153 ops/sec ±0.19%  | x 122 ops/sec ±0.61%     |  Fast  |
+| getRandomBytes      | x 207,866 ops/sec ±0.23% | x 299,959 ops/sec ±0.39% |  Slow  |
+| getKeyPair          | x 38,815 ops/sec ±0.16%  | x 242 ops/sec ±0.62%     |  Fast  |
 
 ## License
 

--- a/packages/lisk-cryptography/README.md
+++ b/packages/lisk-cryptography/README.md
@@ -1,1 +1,68 @@
-# lisk-cryptography
+# @liskhq/lisk-cryptography
+
+@liskhq/lisk-cryptography is containing general cryptographic functions for use with Lisk-related software
+
+## Installation
+
+```sh
+$ npm install --save @liskhq/lisk-cryptography
+```
+
+## Benchmarking
+
+Install optional dependencies:
+
+```sh
+$ npm i -D benchmark sodium-native
+```
+
+Benchmark nacl functions:
+
+```sh
+$ npx babel-node ./benchmark/nacl
+```
+
+Benchmark results for nacl functions:
+
+| Function            | Results                                                         | Winner |      
+| ------------------- | ----------------------------------------------------------------| ------ |       
+| fast.box            | fast.box x 23,982 ops/sec ±0.59%                                |   ✓    |
+| slow.box            | slow.box x 771 ops/sec ±0.44%                                   |        |
+| fast.openBox        | fast.openBox x 24,247 ops/sec ±0.42%                            |   ✓    |
+| slow.openBox        | slow.openBox x 770 ops/sec ±0.69%                               |        |
+| fast.signDetached   | fast.signDetached x 46,402 ops/sec ±0.32%                       |   ✓    |
+| slow.signDetached   | slow.signDetached x 236 ops/sec ±1.63%                          |        |
+| fast.verifyDetached | fast.verifyDetached x 17,153 ops/sec ±0.19%                     |   ✓    |
+| slow.verifyDetached | slow.verifyDetached x 122 ops/sec ±0.61%                        |        |
+| fast.getRandomBytes | fast.getRandomBytes x 207,866 ops/sec ±0.23%                    |        |
+| slow.getRandomBytes | slow.getRandomBytes x 299,959 ops/sec ±0.39%                    |   ✓    |
+| fast.getKeyPair     | fast.getKeyPair x 38,815 ops/sec ±0.16%                         |   ✓    |
+| slow.getKeyPair     | slow.getKeyPair x 242 ops/sec ±0.62%                            |        |
+
+## License
+
+Copyright © 2016-2018 Lisk Foundation
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the [GNU General Public License](https://github.com/LiskHQ/lisk-elements/tree/master/LICENSE) along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+***
+
+This program also incorporates work previously released with lisk-js `v0.5.2` (and earlier) versions under the [MIT License](https://opensource.org/licenses/MIT). To comply with the requirements of that license, the following permission notice, applicable to those parts of the code only, is included below:
+
+Copyright © 2016-2017 Lisk Foundation
+
+Copyright © 2015 Crypti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+[Lisk Core GitHub]: https://github.com/LiskHQ/lisk
+[Lisk documentation site]: https://lisk.io/documentation/lisk-elements

--- a/packages/lisk-cryptography/benchmark/nacl.js
+++ b/packages/lisk-cryptography/benchmark/nacl.js
@@ -12,7 +12,6 @@
 * Removal or modification of this copyright notice is prohibited.
 *
 */
-/* eslint-disable no-console */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import Benchmark from 'benchmark';
 import * as fast from '../src/nacl/fast';
@@ -131,13 +130,13 @@ const getKeyPairBenchmark = new Benchmark.Suite('getKeyPair')
 ].forEach(benchmark => {
 	benchmark
 		.on('start', () => {
-			console.log(`Evaluating ${benchmark.name}..`);
+			console.info(`Evaluating ${benchmark.name}..`);
 		})
 		.on('cycle', event => {
-			console.log(String(event.target));
+			console.info(String(event.target));
 		})
 		.on('complete', function callback() {
-			console.log(`Winner is ${this.filter('fastest').map('name')}!`);
+			console.info(`Winner is ${this.filter('fastest').map('name')}!`);
 		})
 		.run();
 });

--- a/packages/lisk-cryptography/benchmark/nacl.js
+++ b/packages/lisk-cryptography/benchmark/nacl.js
@@ -1,0 +1,143 @@
+/*
+* Copyright © 2018 Lisk Foundation
+*
+* See the LICENSE file at the top-level directory of this distribution
+* for licensing information.
+*
+* Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+* no part of this software, including this file, may be copied, modified,
+* propagated, or distributed except according to the terms contained in the
+* LICENSE file.
+*
+* Removal or modification of this copyright notice is prohibited.
+*
+*/
+/* eslint-disable no-console */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import Benchmark from 'benchmark';
+import * as fast from '../src/nacl/fast';
+import * as slow from '../src/nacl/slow';
+
+Benchmark.options.minSamples = 100;
+
+const defaultPublicKey =
+	'7ef45cd525e95b7a86244bbd4eb4550914ad06301013958f4dd64d32ef7bc588';
+const defaultPrivateKey =
+	'314852d7afb0d4c283692fef8a2cb40e30c7a5df2ed79994178c10ac168d6d977ef45cd525e95b7a86244bbd4eb4550914ad06301013958f4dd64d32ef7bc588';
+const defaultMessage = 'Some default text.';
+const defaultSignature =
+	'68937004b6720d7e1902ef05a577e6d9f9ab2756286b1f2ae918f8a0e5153c15e4f410916076f750b708f8979be2430e4cfc7ebb523ae1905d2ea1f5d24ce700';
+const defaultEncryptedMessage =
+	'a232e5ea10e18249efc5a0aa8ed68271fc494d02245c52277ee2e14cddd960144a65';
+const defaultNonce = 'df4c8b09e270d2cb3f7b3d53dfa8a6f3441ad3b14a13fb66';
+const defaultHash =
+	'314852d7afb0d4c283692fef8a2cb40e30c7a5df2ed79994178c10ac168d6d97';
+const defaultDigest =
+	'aba8462bb7a1460f1e36c36a71f0b7f67d1606562001907c1b2dad08a8ce74ae';
+const defaultConvertedPublicKeyEd2Curve =
+	'b8c0eecfd16c1cc4f057a6fc6d8dd3d46e4aa9625408d4bd0ba00e991326fe00';
+const defaultConvertedPrivateKeyEd2Curve =
+	'b0e3276b64b086b381e11928e56f966d062dc677b7801cc594aeb2d4193e8d57';
+
+const boxBenchmark = new Benchmark.Suite('box')
+	.add('fast.box', () => {
+		fast.box(
+			Buffer.from(defaultMessage, 'utf8'),
+			Buffer.from(defaultNonce, 'hex'),
+			Buffer.from(defaultConvertedPublicKeyEd2Curve, 'hex'),
+			Buffer.from(defaultConvertedPrivateKeyEd2Curve, 'hex'),
+		);
+	})
+	.add('slow.box', () => {
+		slow.box(
+			Buffer.from(defaultMessage, 'utf8'),
+			Buffer.from(defaultNonce, 'hex'),
+			Buffer.from(defaultConvertedPublicKeyEd2Curve, 'hex'),
+			Buffer.from(defaultConvertedPrivateKeyEd2Curve, 'hex'),
+		);
+	});
+
+const openBoxBenchmark = new Benchmark.Suite('openBox')
+	.add('fast.openBox', () => {
+		fast.openBox(
+			Buffer.from(defaultEncryptedMessage, 'hex'),
+			Buffer.from(defaultNonce, 'hex'),
+			Buffer.from(defaultConvertedPublicKeyEd2Curve, 'hex'),
+			Buffer.from(defaultConvertedPrivateKeyEd2Curve, 'hex'),
+		);
+	})
+	.add('slow.openBox', () => {
+		slow.openBox(
+			Buffer.from(defaultEncryptedMessage, 'hex'),
+			Buffer.from(defaultNonce, 'hex'),
+			Buffer.from(defaultConvertedPublicKeyEd2Curve, 'hex'),
+			Buffer.from(defaultConvertedPrivateKeyEd2Curve, 'hex'),
+		);
+	});
+
+const signDetachedBenchmark = new Benchmark.Suite('signDetached')
+	.add('fast.signDetached', () => {
+		fast.signDetached(
+			Buffer.from(defaultDigest, 'hex'),
+			Buffer.from(defaultPrivateKey, 'hex'),
+		);
+	})
+	.add('slow.signDetached', () => {
+		slow.signDetached(
+			Buffer.from(defaultDigest, 'hex'),
+			Buffer.from(defaultPrivateKey, 'hex'),
+		);
+	});
+
+const verifyDetachedBenchmark = new Benchmark.Suite('verifyDetached')
+	.add('fast.verifyDetached', () => {
+		fast.verifyDetached(
+			Buffer.from(defaultDigest, 'hex'),
+			Buffer.from(defaultSignature, 'hex'),
+			Buffer.from(defaultPublicKey, 'hex'),
+		);
+	})
+	.add('slow.verifyDetached', () => {
+		slow.verifyDetached(
+			Buffer.from(defaultDigest, 'hex'),
+			Buffer.from(defaultSignature, 'hex'),
+			Buffer.from(defaultPublicKey, 'hex'),
+		);
+	});
+
+const getRandomBytesBenchmark = new Benchmark.Suite('getRandomBytes')
+	.add('fast.getRandomBytes', () => {
+		fast.getRandomBytes(24);
+	})
+	.add('slow.getRandomBytes', () => {
+		slow.getRandomBytes(24);
+	});
+
+const getKeyPairBenchmark = new Benchmark.Suite('getKeyPair')
+	.add('fast.getKeyPair', () => {
+		fast.getKeyPair(Buffer.from(defaultHash, 'hex'));
+	})
+	.add('slow.getKeyPair', () => {
+		slow.getKeyPair(Buffer.from(defaultHash, 'hex'));
+	});
+
+[
+	boxBenchmark,
+	openBoxBenchmark,
+	signDetachedBenchmark,
+	verifyDetachedBenchmark,
+	getRandomBytesBenchmark,
+	getKeyPairBenchmark,
+].forEach(benchmark => {
+	benchmark
+		.on('start', () => {
+			console.log(`Evaluating ${benchmark.name}..`);
+		})
+		.on('cycle', event => {
+			console.log(String(event.target));
+		})
+		.on('complete', function callback() {
+			console.log(`Winner is ${this.filter('fastest').map('name')}!`);
+		})
+		.run();
+});

--- a/packages/lisk-cryptography/package-lock.json
+++ b/packages/lisk-cryptography/package-lock.json
@@ -434,6 +434,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+<<<<<<< HEAD
 			"dev": true
 		},
 		"arr-union": {
@@ -441,6 +442,10 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
+=======
+			"dev": true,
+			"optional": true
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 		},
 		"array-filter": {
 			"version": "0.0.1",
@@ -550,12 +555,15 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+<<<<<<< HEAD
 			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+=======
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 			"dev": true
 		},
 		"async": {
@@ -1384,6 +1392,16 @@
 				}
 			}
 		},
+		"benchmark": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+			"integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.4",
+				"platform": "^1.3.3"
+			}
+		},
 		"binary-extensions": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -1943,6 +1961,7 @@
 			"version": "2.18.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
 			"integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
+<<<<<<< HEAD
 			"dev": true
 		},
 		"common-tags": {
@@ -1958,6 +1977,8 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+=======
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 			"dev": true
 		},
 		"concat-map": {
@@ -2720,12 +2741,15 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+<<<<<<< HEAD
 					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+=======
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"ms": {
@@ -3422,24 +3446,44 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3449,12 +3493,22 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -3463,34 +3517,64 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3499,25 +3583,45 @@
 				},
 				"deep-extend": {
 					"version": "0.5.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3526,13 +3630,23 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3548,7 +3662,12 @@
 				},
 				"glob": {
 					"version": "7.1.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3562,13 +3681,23 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3577,7 +3706,12 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3586,7 +3720,12 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3596,18 +3735,33 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -3615,13 +3769,23 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -3629,12 +3793,22 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
@@ -3643,7 +3817,12 @@
 				},
 				"minizlib": {
 					"version": "1.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3652,7 +3831,12 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -3660,13 +3844,23 @@
 				},
 				"ms": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3677,7 +3871,12 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.10.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3695,7 +3894,12 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3705,13 +3909,23 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3721,7 +3935,12 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3733,18 +3952,33 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"wrappy": "1"
@@ -3752,19 +3986,34 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3774,19 +4023,34 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3798,7 +4062,12 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"optional": true
 						}
@@ -3806,7 +4075,12 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3821,7 +4095,12 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3830,42 +4109,77 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -3875,7 +4189,12 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3884,7 +4203,12 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -3892,13 +4216,23 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3913,13 +4247,23 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -3928,12 +4272,22 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				}
 			}
@@ -5469,6 +5823,7 @@
 			"dev": true
 		},
 		"nan": {
+<<<<<<< HEAD
 			"version": "2.11.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
 			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
@@ -5516,6 +5871,12 @@
 					"optional": true
 				}
 			}
+=======
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+			"integrity": "sha1-V042Dk2VSrFpZuwQLAwEn9lhoJk=",
+			"dev": true
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -5639,7 +6000,12 @@
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2",
@@ -5649,17 +6015,32 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"append-transform": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"default-require-extensions": "^2.0.0"
@@ -5667,27 +6048,52 @@
 				},
 				"archy": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -5696,12 +6102,22 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"caching-transform": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-tTfemGmFWe7KZ3KN6VsSgQZbd9Bgo7A40wlp4PTsJJvFu4YAnEC5YnfdiKq6Vh2i9XJLnA9n8OXD46orVpnPMw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"make-dir": "^1.0.0",
@@ -5712,13 +6128,23 @@
 				},
 				"camelcase": {
 					"version": "1.2.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -5728,7 +6154,12 @@
 				},
 				"cliui": {
 					"version": "2.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -5739,7 +6170,12 @@
 					"dependencies": {
 						"wordwrap": {
 							"version": "0.0.2",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"optional": true
 						}
@@ -5747,27 +6183,52 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"commondir": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -5776,7 +6237,12 @@
 				},
 				"debug": {
 					"version": "3.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -5784,17 +6250,32 @@
 				},
 				"debug-log": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"strip-bom": "^3.0.0"
@@ -5802,7 +6283,12 @@
 				},
 				"error-ex": {
 					"version": "1.3.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
@@ -5810,12 +6296,22 @@
 				},
 				"es6-error": {
 					"version": "4.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -5829,7 +6325,12 @@
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
@@ -5841,7 +6342,12 @@
 				},
 				"find-cache-dir": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
@@ -5851,7 +6357,12 @@
 				},
 				"find-up": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
@@ -5859,7 +6370,12 @@
 				},
 				"foreground-child": {
 					"version": "1.5.6",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^4",
@@ -5868,22 +6384,42 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -5896,12 +6432,22 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"async": "^1.4.0",
@@ -5912,7 +6458,12 @@
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"amdefine": ">=0.0.4"
@@ -5922,22 +6473,42 @@
 				},
 				"has-flag": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.7.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -5946,27 +6517,52 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
@@ -5974,27 +6570,52 @@
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"istanbul-lib-coverage": {
 					"version": "2.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "2.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-ufiZoiJ8CxY577JJWEeFuxXZoMqiKpq/RqZtOAYuQLvlkbJWscq9n3gc4xrCGH9n4pW0qnTxOz1oyMmVtk8E1w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"append-transform": "^1.0.0"
@@ -6002,7 +6623,12 @@
 				},
 				"istanbul-lib-report": {
 					"version": "2.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-pXYOWwpDNc5AHIY93WjFTuxzkDOOZ7B8eSa0cBHTmTnKRst5ccc/xBfWu/5wcNJqB6/Qy0lDMhpn+Uy0qyyUjA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "^2.0.1",
@@ -6012,7 +6638,12 @@
 				},
 				"istanbul-lib-source-maps": {
 					"version": "2.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
@@ -6024,14 +6655,24 @@
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true
 						}
 					}
 				},
 				"istanbul-reports": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-d2YRSnAOHHb+6vMc5qjJEyPN4VapkgUMhKlMmr3BzKdMDWdJbyYGEi/7m5AjDjkvRRTjs68ttPRZ7W2jBZ31SQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"handlebars": "^4.0.11"
@@ -6039,12 +6680,22 @@
 				},
 				"json-parse-better-errors": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -6052,13 +6703,23 @@
 				},
 				"lazy-cache": {
 					"version": "1.0.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
@@ -6066,7 +6727,12 @@
 				},
 				"load-json-file": {
 					"version": "4.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -6077,7 +6743,12 @@
 				},
 				"locate-path": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
@@ -6086,17 +6757,32 @@
 				},
 				"lodash.flattendeep": {
 					"version": "4.4.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
@@ -6105,7 +6791,12 @@
 				},
 				"make-dir": {
 					"version": "1.3.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
@@ -6113,7 +6804,12 @@
 				},
 				"md5-hex": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
@@ -6121,12 +6817,22 @@
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -6134,7 +6840,12 @@
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"source-map": "^0.6.1"
@@ -6142,19 +6853,34 @@
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -6162,12 +6888,22 @@
 				},
 				"minimist": {
 					"version": "0.0.10",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -6175,19 +6911,34 @@
 					"dependencies": {
 						"minimist": {
 							"version": "0.0.8",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true
 						}
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
@@ -6198,7 +6949,12 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -6206,12 +6962,22 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"once": {
 					"version": "1.4.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"wrappy": "1"
@@ -6219,7 +6985,12 @@
 				},
 				"optimist": {
 					"version": "0.6.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
@@ -6228,12 +6999,22 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
@@ -6243,12 +7024,22 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"p-limit": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -6256,7 +7047,12 @@
 				},
 				"p-locate": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
@@ -6264,12 +7060,22 @@
 				},
 				"p-try": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"package-hash": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
@@ -6280,7 +7086,12 @@
 				},
 				"parse-json": {
 					"version": "4.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
@@ -6289,22 +7100,42 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"path-type": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
@@ -6312,12 +7143,22 @@
 				},
 				"pify": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"pkg-dir": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0"
@@ -6325,12 +7166,22 @@
 				},
 				"pseudomap": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
@@ -6340,7 +7191,12 @@
 				},
 				"read-pkg-up": {
 					"version": "4.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
@@ -6349,7 +7205,12 @@
 				},
 				"release-zalgo": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"es6-error": "^4.0.1"
@@ -6357,27 +7218,52 @@
 				},
 				"repeat-string": {
 					"version": "1.6.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"resolve-from": {
 					"version": "4.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -6386,7 +7272,12 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -6394,17 +7285,32 @@
 				},
 				"semver": {
 					"version": "5.5.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -6412,23 +7318,43 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"foreground-child": "^1.5.6",
@@ -6441,7 +7367,12 @@
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
@@ -6450,12 +7381,22 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
@@ -6464,12 +7405,22 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
@@ -6478,7 +7429,12 @@
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
@@ -6486,17 +7442,32 @@
 				},
 				"strip-bom": {
 					"version": "3.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"strip-eof": {
 					"version": "1.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -6504,7 +7475,12 @@
 				},
 				"test-exclude": {
 					"version": "5.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"arrify": "^1.0.1",
@@ -6515,7 +7491,12 @@
 				},
 				"uglify-js": {
 					"version": "2.8.29",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -6526,7 +7507,12 @@
 					"dependencies": {
 						"yargs": {
 							"version": "3.10.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -6540,18 +7526,33 @@
 				},
 				"uglify-to-browserify": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"uuid": {
 					"version": "3.3.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
@@ -6560,7 +7561,12 @@
 				},
 				"which": {
 					"version": "1.3.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -6568,23 +7574,43 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -6593,12 +7619,22 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "2.1.1",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
@@ -6606,7 +7642,12 @@
 						},
 						"string-width": {
 							"version": "1.0.2",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -6616,7 +7657,12 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
@@ -6626,12 +7672,22 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "2.3.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
@@ -6641,17 +7697,32 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true
 				},
 				"yargs": {
 					"version": "11.1.0",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
@@ -6670,7 +7741,12 @@
 					"dependencies": {
 						"cliui": {
 							"version": "4.1.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"string-width": "^2.1.1",
@@ -6680,7 +7756,12 @@
 						},
 						"find-up": {
 							"version": "2.1.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"locate-path": "^2.0.0"
@@ -6688,7 +7769,12 @@
 						},
 						"locate-path": {
 							"version": "2.0.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"p-locate": "^2.0.0",
@@ -6697,7 +7783,12 @@
 						},
 						"p-limit": {
 							"version": "1.3.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"p-try": "^1.0.0"
@@ -6705,7 +7796,12 @@
 						},
 						"p-locate": {
 							"version": "2.0.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true,
 							"requires": {
 								"p-limit": "^1.1.0"
@@ -6713,14 +7809,24 @@
 						},
 						"p-try": {
 							"version": "1.0.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true
 						}
 					}
 				},
 				"yargs-parser": {
 					"version": "9.0.2",
+<<<<<<< HEAD
 					"bundled": true,
+=======
+					"resolved": false,
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -6728,7 +7834,12 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
+<<<<<<< HEAD
 							"bundled": true,
+=======
+							"resolved": false,
+							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 							"dev": true
 						}
 					}
@@ -7235,6 +8346,12 @@
 				}
 			}
 		},
+		"platform": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+			"integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+			"dev": true
+		},
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -7453,9 +8570,51 @@
 			}
 		},
 		"readdirp": {
+<<<<<<< HEAD
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
 			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+=======
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
+			}
+		},
+		"regenerate": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"dev": true
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
+		},
+		"regenerator-transform": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -7476,6 +8635,7 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 					"dev": true
+<<<<<<< HEAD
 				},
 				"braces": {
 					"version": "2.3.2",
@@ -7844,6 +9004,8 @@
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
 					"dev": true
+=======
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 				}
 			}
 		},
@@ -8023,6 +9185,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+<<<<<<< HEAD
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -8032,6 +9195,8 @@
 			"requires": {
 				"ret": "~0.1.10"
 			}
+=======
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -8173,6 +9338,7 @@
 			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 			"dev": true
 		},
+<<<<<<< HEAD
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -8288,6 +9454,8 @@
 				"kind-of": "^3.2.0"
 			}
 		},
+=======
+>>>>>>> 0808712... :white_check_mark: Add benchmark for nacl libraries
 		"sodium-native": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",

--- a/packages/lisk-cryptography/package.json
+++ b/packages/lisk-cryptography/package.json
@@ -66,7 +66,8 @@
 		"varuint-bitcoin": "1.1.0"
 	},
 	"optionalDependencies": {
-		"sodium-native": "2.2.1"
+		"sodium-native": "2.2.1",
+		"benchmark": "2.1.4"
 	},
 	"devDependencies": {
 		"babel-cli": "6.26.0",

--- a/packages/lisk-cryptography/package.json
+++ b/packages/lisk-cryptography/package.json
@@ -66,8 +66,7 @@
 		"varuint-bitcoin": "1.1.0"
 	},
 	"optionalDependencies": {
-		"sodium-native": "2.2.1",
-		"benchmark": "2.1.4"
+		"sodium-native": "2.2.1"
 	},
 	"devDependencies": {
 		"babel-cli": "6.26.0",
@@ -76,6 +75,7 @@
 		"babel-plugin-transform-runtime": "6.23.0",
 		"babel-preset-env": "1.7.0",
 		"babel-register": "6.26.0",
+		"benchmark": "2.1.4",
 		"browserify": "16.2.2",
 		"chai": "4.1.2",
 		"cypress": "3.1.0",


### PR DESCRIPTION
### What was the problem?

We do not have any benchmark to evaluate the performance of tweetnacl vs. sodium-native.

### How did I fix it?

Create benchmark for nacl functions.

### How to test it?

In packages/lisk-cryptography:
`npm i -D benchmark sodium-native`
`npx babel-node ./benchmark/nacl`

### Review checklist

* The PR resolves #789 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
