### PR TITLE
Change tslint filename rule from camelCase to Snake_case - Closes #811

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
 		"tslint-config-prettier"
 	],
 	"rules": {
+		"file-name-casing": "snake-case",
 		"interface-name": [true, "never-prefix"],
 		"no-class": false,
 		"no-delete": true,
@@ -22,7 +23,6 @@
 		"object-literal-sort-keys": [true, "match-declaration-order"],
 		"prefer-method-signature": false,
 		"readonly-array": true,
-		"readonly-keyword": [true, "ignore-class"],
-		"file-name-casing": "snake-case"
+		"readonly-keyword": [true, "ignore-class"]
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -22,6 +22,7 @@
 		"object-literal-sort-keys": [true, "match-declaration-order"],
 		"prefer-method-signature": false,
 		"readonly-array": true,
-		"readonly-keyword": [true, "ignore-class"]
+		"readonly-keyword": [true, "ignore-class"],
+		"file-name-casing": "snake-case"
 	}
 }


### PR DESCRIPTION
### What was the problem?
Filename to be snake_case instead of camelCase
### How did I fix it?
Add rule in `tslint.json` file `"file-name-casing": "snake-case"`
### How to test it?
`npm run lint`
### Review checklist

* The PR resolves #811
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
