### PR TITLE
Disable completed-docs rule for tslint - Closes #819

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
 		"tslint-config-prettier"
 	],
 	"rules": {
+		"completed-docs": false,
 		"file-name-casing": "snake-case",
 		"interface-name": [true, "never-prefix"],
 		"no-class": false,


### PR DESCRIPTION
### Description
Removing `completed-docs` rules we currently don't use JSDocs and we have documentation in other format.

### Review checklist

* The PR resolves #819
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
