### PR TITLE
Disable strict-boolean-expressions - Closes #818

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -23,6 +23,7 @@
 		"object-literal-sort-keys": [true, "match-declaration-order"],
 		"prefer-method-signature": false,
 		"readonly-array": true,
-		"readonly-keyword": [true, "ignore-class"]
+		"readonly-keyword": [true, "ignore-class"],
+		"strict-boolean-expressions": false
 	}
 }


### PR DESCRIPTION
### What was the problem?
We currently have a lot of code where we check string, undefined null existence.
Also, we are using `const a = input || defaultValue` this kind of codes everywhere.
Therefore, temporally disabling it

### Review checklist

* The PR resolves #818 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
