### PR TITLE
Disable Filename, object odering, and type predicates - Closes #826

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,7 @@
 	],
 	"rules": {
 		"completed-docs": false,
-		"file-name-casing": "snake-case",
+		"file-name-casing": false,
 		"interface-name": [true, "never-prefix"],
 		"no-class": false,
 		"no-delete": true,
@@ -22,10 +22,11 @@
 		"no-this": false,
 		"no-unsafe-any": false,
 		"no-var-keyword": true,
-		"object-literal-sort-keys": [true, "match-declaration-order"],
+		"object-literal-sort-keys": false,
 		"prefer-method-signature": false,
 		"readonly-array": true,
 		"readonly-keyword": [true, "ignore-class"],
-		"strict-boolean-expressions": false
+		"strict-boolean-expressions": false,
+		"strict-type-predicates": false
 	}
 }


### PR DESCRIPTION
### What was the problem?
TSLint config was too strict.

object-literal-sort-keys: false => object order often has more meaning in order than alphabetical
strict-type-predicates: false => better to check considering non-typescript usecase
file-name-casing: false => snake_case is not supported

### Review checklist

* The PR resolves #826 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
