### PR TITLE
Remove browser publish script

### DIFF
--- a/packages/lisk-client/package.json
+++ b/packages/lisk-client/package.json
@@ -57,10 +57,7 @@
 		"prebuild": "npm run prebuild:browser",
 		"build": "npm run build:browser",
 		"build:check": "node -e \"require('./dist-node')\"",
-		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check",
-		"prepublish:browser": "npm run prepublishOnly",
-		"publish:browser": "./scripts/publish_browser.sh",
-		"postpublish": "npm run publish:browser"
+		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
 	"dependencies": {
 		"@liskhq/lisk-api-client": "1.1.0",

--- a/packages/lisk-elements/package.json
+++ b/packages/lisk-elements/package.json
@@ -57,10 +57,7 @@
 		"prebuild": "npm run prebuild:browser",
 		"build": "npm run build:browser",
 		"build:check": "node -e \"require('./dist-node')\"",
-		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check",
-		"prepublish:browser": "npm run prepublishOnly",
-		"publish:browser": "./scripts/publish_browser.sh",
-		"postpublish": "npm run publish:browser"
+		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
 	"dependencies": {
 		"@liskhq/lisk-api-client": "1.1.0",


### PR DESCRIPTION
### What was the problem?
Build script for the browser publish was removed pre 1.0 release, but at some point only the package.json script came back

### How did I fix it?
Remove the unneeded npm script

### Review checklist

* The PR resolves #836
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
