### PR TITLE
Remove outdated zero transfer amount test - Closes #837

### DIFF
--- a/packages/lisk-transactions/test/utils/get_transaction_bytes.ts
+++ b/packages/lisk-transactions/test/utils/get_transaction_bytes.ts
@@ -125,17 +125,6 @@ describe('getTransactionBytes module', () => {
 				);
 			});
 
-			it('should not throw on type 0 with an amount that is 0', () => {
-				const amount = 0;
-				const transaction = {
-					...defaultTransaction,
-					amount,
-				};
-				return expect(
-					getTransactionBytes.bind(null, transaction),
-				).not.to.throw();
-			});
-
 			it('should throw on type 0 with an amount that is too large', () => {
 				const amount = BigNum.fromBuffer(
 					Buffer.from(new Array(8).fill(255)),


### PR DESCRIPTION
### What was the problem?

`getTransactionBytes` test suite had outdated test to check for allowing 0 transfer transactions.

### How did I fix it?

Removed outdated test

### How to test it?

npm run test

### Review checklist

* The PR resolves #837 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
