### PR TITLE
Update address validation - Closes #832

### DIFF
--- a/packages/lisk-transactions/src/utils/validation/validation.ts
+++ b/packages/lisk-transactions/src/utils/validation/validation.ts
@@ -68,7 +68,7 @@ export const validateKeysgroup = (keysgroup: ReadonlyArray<string>) => {
 const MIN_ADDRESS_LENGTH = 2;
 const MAX_ADDRESS_LENGTH = 22;
 const BASE_TEN = 10;
-export const validateAddress = (address: string) => {
+export const validateAddress = (address: string): boolean => {
 	if (
 		address.length < MIN_ADDRESS_LENGTH ||
 		address.length > MAX_ADDRESS_LENGTH
@@ -100,7 +100,9 @@ export const validateAddress = (address: string) => {
 	}
 
 	if (addressString !== addressNumber.toString(BASE_TEN)) {
-		throw new Error('Address number does not have natural representation.');
+		throw new Error(
+			"Address string format does not match it's number representation.",
+		);
 	}
 
 	return true;

--- a/packages/lisk-transactions/src/utils/validation/validation.ts
+++ b/packages/lisk-transactions/src/utils/validation/validation.ts
@@ -67,6 +67,7 @@ export const validateKeysgroup = (keysgroup: ReadonlyArray<string>) => {
 
 const MIN_ADDRESS_LENGTH = 2;
 const MAX_ADDRESS_LENGTH = 22;
+const BASE_TEN = 10;
 export const validateAddress = (address: string) => {
 	if (
 		address.length < MIN_ADDRESS_LENGTH ||
@@ -83,12 +84,23 @@ export const validateAddress = (address: string) => {
 		);
 	}
 
-	const addressAsBignum = new BigNum(address.slice(0, -1));
+	if (address.indexOf('.') > -1) {
+		throw new Error(
+			'Address format does not match requirements. Address includes invalid character: `.`.',
+		);
+	}
 
-	if (addressAsBignum.cmp(new BigNum(MAX_ADDRESS_NUMBER)) > 0) {
+	const addressString = address.slice(0, -1);
+	const addressNumber = new BigNum(addressString);
+
+	if (addressNumber.cmp(new BigNum(MAX_ADDRESS_NUMBER)) > 0) {
 		throw new Error(
 			'Address format does not match requirements. Address out of maximum range.',
 		);
+	}
+
+	if (addressString !== addressNumber.toString(BASE_TEN)) {
+		throw new Error('Address number does not have natural representation.');
 	}
 
 	return true;

--- a/packages/lisk-transactions/test/utils/validation/validation.ts
+++ b/packages/lisk-transactions/test/utils/validation/validation.ts
@@ -183,7 +183,7 @@ describe('validation', () => {
 				'922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 				'922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 			];
-			it('should throw', () => {
+			it('should throw an error', () => {
 				return expect(
 					checkPublicKeysForDuplicates.bind(null, publicKeys),
 				).to.throw(
@@ -210,60 +210,55 @@ describe('validation', () => {
 
 		describe('Given an address that is too short', () => {
 			const address = 'L';
-			const error =
-				'Address length does not match requirements. Expected between 2 and 22 characters.';
-
-			it('should throw', () => {
-				return expect(validateAddress.bind(null, address)).to.throw(error);
+			it('should throw an error', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(
+					'Address length does not match requirements. Expected between 2 and 22 characters.',
+				);
 			});
 		});
 
 		describe('Given an address that is too long', () => {
 			const address = '12345678901234567890123L';
-			const error =
-				'Address length does not match requirements. Expected between 2 and 22 characters.';
-
-			it('should throw', () => {
-				return expect(validateAddress.bind(null, address)).to.throw(error);
+			it('should throw an error', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(
+					'Address length does not match requirements. Expected between 2 and 22 characters.',
+				);
 			});
 		});
 
 		describe('Given an address without L at the end', () => {
 			const address = '1234567890';
-			const error =
-				'Address format does not match requirements. Expected "L" at the end.';
-
-			it('should throw', () => {
-				return expect(validateAddress.bind(null, address)).to.throw(error);
+			it('should throw an error', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(
+					'Address format does not match requirements. Expected "L" at the end.',
+				);
 			});
 		});
 
 		describe('Given an address that includes `.`', () => {
 			const address = '14.15133512790761431L';
-			const error =
-				'Address format does not match requirements. Address includes invalid character: `.`.';
-
-			it('should throw', () => {
-				return expect(validateAddress.bind(null, address)).to.throw(error);
+			it('should throw an error', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(
+					'Address format does not match requirements. Address includes invalid character: `.`.',
+				);
 			});
 		});
 
 		describe('Given an address that is out of range', () => {
 			const address = '18446744073709551616L';
-			const error =
-				'Address format does not match requirements. Address out of maximum range.';
-
-			it('should throw', () => {
-				return expect(validateAddress.bind(null, address)).to.throw(error);
+			it('should throw an error', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(
+					'Address format does not match requirements. Address out of maximum range.',
+				);
 			});
 		});
 
 		describe('Given an address that has leading zeros', () => {
 			const address = '00015133512790761431L';
-			const error = 'Address number does not have natural representation.';
-
-			it('should throw', () => {
-				return expect(validateAddress.bind(null, address)).to.throw(error);
+			it('should throw an error', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(
+					"Address string format does not match it's number representation.",
+				);
 			});
 		});
 	});

--- a/packages/lisk-transactions/test/utils/validation/validation.ts
+++ b/packages/lisk-transactions/test/utils/validation/validation.ts
@@ -238,10 +238,29 @@ describe('validation', () => {
 			});
 		});
 
+		describe('Given an address that includes `.`', () => {
+			const address = '14.15133512790761431L';
+			const error =
+				'Address format does not match requirements. Address includes invalid character: `.`.';
+
+			it('should throw', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(error);
+			});
+		});
+
 		describe('Given an address that is out of range', () => {
 			const address = '18446744073709551616L';
 			const error =
 				'Address format does not match requirements. Address out of maximum range.';
+
+			it('should throw', () => {
+				return expect(validateAddress.bind(null, address)).to.throw(error);
+			});
+		});
+
+		describe('Given an address that has leading zeros', () => {
+			const address = '00015133512790761431L';
+			const error = 'Address number does not have natural representation.';
 
 			it('should throw', () => {
 				return expect(validateAddress.bind(null, address)).to.throw(error);

--- a/packages/lisk-transactions/test/utils/validation/validator.ts
+++ b/packages/lisk-transactions/test/utils/validation/validator.ts
@@ -146,8 +146,12 @@ describe('validator', () => {
 			return expect(validate({ target: '14815133512790761431L' })).to.be.true;
 		});
 
-		it('should validate to true when valid address with leading zeros is provided', () => {
-			return expect(validate({ target: '00015133512790761431L' })).to.be.true;
+		it('should validate to false when address with leading zeros is provided', () => {
+			return expect(validate({ target: '00015133512790761431L' })).to.be.false;
+		});
+
+		it('should validate to false when address including `.` is provided', () => {
+			return expect(validate({ target: '14.15133512790761431L' })).to.be.false;
 		});
 
 		it('should validate to false when number greater than maximum is provided', () => {


### PR DESCRIPTION
### What was the problem?

Address validation allowed leading zeros and inclusion of `.` character.

### How did I fix it?

Updated `validateAddress` in utils.

### How to test it?

npm run test

### Review checklist

* The PR resolves #832 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
