### PR TITLE
Remove transaction interface from exposing

### DIFF
--- a/packages/lisk-transactions/src/index.ts
+++ b/packages/lisk-transactions/src/index.ts
@@ -22,30 +22,6 @@ import * as constants from './constants';
 import { createSignatureObject } from './create_signature_object';
 import * as utils from './utils';
 
-import {
-	BaseTransaction,
-	DappTransaction,
-	DelegateTransaction,
-	InTransferTransaction,
-	MultiSignatureTransaction,
-	OutTransferTransaction,
-	SecondSignatureTransaction,
-	TransferTransaction,
-	VoteTransaction,
-} from './transaction_types';
-
-export {
-	BaseTransaction,
-	DappTransaction,
-	DelegateTransaction,
-	InTransferTransaction,
-	MultiSignatureTransaction,
-	OutTransferTransaction,
-	SecondSignatureTransaction,
-	TransferTransaction,
-	VoteTransaction,
-};
-
 // tslint:disable-next-line no-default-export
 export default {
 	transfer,


### PR DESCRIPTION
### What was the problem?
Because we will have new transaction type on the next 2.1 version, we should not actively expose the type otherwise it will be a breaking change again.

### Review checklist

* The PR resolves #848 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
