### PR TITLE
Add missing unit test after typescript migration - Closes #844

### DIFF
--- a/packages/lisk-api-client/src/api_method.ts
+++ b/packages/lisk-api-client/src/api_method.ts
@@ -64,20 +64,25 @@ export const apiMethod = (options: RequestConfig = {}): ApiHandler =>
 		}
 
 		const resolvedURLObject = urlParams.reduce(
-			(accumulator: HashMap = {}, param: string, i: number): HashMap => ({
-				...accumulator,
-				[param]: args[i] as string,
-			}),
+			// tslint:disable-next-line no-inferred-empty-object-type
+			(accumulator: HashMap, param: string, i: number): HashMap => {
+				const value = args[i];
+				if (typeof value !== 'string' && typeof value !== 'number') {
+					throw new Error('Parameter must be a string or a number');
+				}
+
+				return {
+					...accumulator,
+					[param]: typeof value === 'number' ? value.toString() : value,
+				};
+			},
 			{},
 		);
 
 		const requestData: AxiosRequestConfig = {
 			headers: this.headers,
 			method,
-			url: solveURLParams(
-				`${this.resourcePath}${path}`,
-				resolvedURLObject as HashMap,
-			),
+			url: solveURLParams(`${this.resourcePath}${path}`, resolvedURLObject),
 		};
 
 		if (Object.keys(data).length > 0) {

--- a/packages/lisk-api-client/src/api_types.ts
+++ b/packages/lisk-api-client/src/api_types.ts
@@ -14,8 +14,8 @@
  */
 /* tslint:disable no-mixed-interface */
 export type ApiHandler = (
-	resource: Resource,
-	args: ReadonlyArray<number | string | object>,
+	// tslint:disable-next-line readonly-array
+	...args: Array<number | string | object>
 ) => Promise<ApiResponse | Error>;
 
 export interface ApiResponse {

--- a/packages/lisk-api-client/test/api_method.ts
+++ b/packages/lisk-api-client/test/api_method.ts
@@ -14,7 +14,7 @@
  */
 import { expect } from 'chai';
 import { apiMethod } from '../src/api_method';
-import { ApiResponse, Resource } from '../src/api_types';
+import { Resource, ApiHandler } from '../src/api_types';
 
 describe('API method module', () => {
 	const GET = 'GET';
@@ -33,14 +33,10 @@ describe('API method module', () => {
 	const errorArgumentNumber =
 		'This endpoint must be supplied with the following parameters: related,id';
 	const firstURLParam = 'r-123';
-	const secondURLParam = 'id-123';
+	const secondURLParam = 123;
 	let resource: Resource;
 	let requestResult: object;
-	let handler: (
-		firstURLParam?: string,
-		secondURLParam?: string,
-		options?: object,
-	) => Promise<ApiResponse | Error>;
+	let handler: ApiHandler;
 	let validationError: Error;
 
 	beforeEach(() => {
@@ -83,6 +79,8 @@ describe('API method module', () => {
 		});
 
 		describe('when initialized with POST / parameters', () => {
+			const parameterStringError = 'Parameter must be a string or a number';
+
 			beforeEach(() => {
 				handler = apiMethod({
 					method: POST,
@@ -114,6 +112,12 @@ describe('API method module', () => {
 					Error,
 					errorArgumentNumber,
 				);
+			});
+
+			it('should throw an error if input is not a string or a number', () => {
+				return expect(
+					handler({ num: 3 }, secondURLParam, { needed: true }),
+				).to.be.rejectedWith(Error, parameterStringError);
 			});
 
 			it('should be rejected with no data', () => {

--- a/packages/lisk-cryptography/src/convert.ts
+++ b/packages/lisk-cryptography/src/convert.ts
@@ -107,7 +107,9 @@ export const parseEncryptedPassphrase = (
 		typeof tag !== 'string' ||
 		typeof version !== 'string'
 	) {
-		throw new Error('Unable to parse encrypted passphrase');
+		throw new Error(
+			'Encrypted passphrase to parse must have only one value per key.',
+		);
 	}
 
 	return {

--- a/packages/lisk-cryptography/src/encrypt.ts
+++ b/packages/lisk-cryptography/src/encrypt.ts
@@ -45,6 +45,7 @@ export const encryptMessageWithPassphrase = (
 	const nonce = getRandomBytes(nonceSize);
 	const publicKeyUint8Array = convertPublicKeyEd2Curve(recipientPublicKeyBytes);
 
+	// This cannot be reproduced, but external library have type union with null
 	if (publicKeyUint8Array === null) {
 		throw new Error('given public key is not a valid Ed25519 public key');
 	}
@@ -85,6 +86,7 @@ export const decryptMessageWithPassphrase = (
 
 	const publicKeyUint8Array = convertPublicKeyEd2Curve(senderPublicKeyBytes);
 
+	// This cannot be reproduced, but external library have type union with null
 	if (publicKeyUint8Array === null) {
 		throw new Error('given public key is not a valid Ed25519 public key');
 	}

--- a/packages/lisk-cryptography/test/convert.ts
+++ b/packages/lisk-cryptography/test/convert.ts
@@ -179,7 +179,7 @@ describe('convert', () => {
 			).to.throw('Could not parse iterations.');
 		});
 
-		it('should throw an error if multiple value in a key', () => {
+		it('should throw an error if multiple values are in a key', () => {
 			const stringifiedEncryptedPassphrase =
 				'salt=xxx&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
 			return expect(

--- a/packages/lisk-cryptography/test/convert.ts
+++ b/packages/lisk-cryptography/test/convert.ts
@@ -179,6 +179,16 @@ describe('convert', () => {
 			).to.throw('Could not parse iterations.');
 		});
 
+		it('should throw an error if multiple value in a key', () => {
+			const stringifiedEncryptedPassphrase =
+				'salt=xxx&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
+			return expect(
+				parseEncryptedPassphrase.bind(null, stringifiedEncryptedPassphrase),
+			).to.throw(
+				'Encrypted passphrase to parse must have only one value per key.',
+			);
+		});
+
 		it('should parse an encrypted passphrase string', () => {
 			const stringifiedEncryptedPassphrase =
 				'salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';

--- a/packages/lisk-cryptography/test/nacl/nacl.ts
+++ b/packages/lisk-cryptography/test/nacl/nacl.ts
@@ -196,7 +196,7 @@ describe('nacl', () => {
 					).to.be.eql(defaultMessage);
 				});
 
-				it('should throw an error with invalid message', () => {
+				it('should throw an error for an invalid message', () => {
 					return expect(
 						openBox.bind(
 							null,

--- a/packages/lisk-cryptography/test/nacl/nacl.ts
+++ b/packages/lisk-cryptography/test/nacl/nacl.ts
@@ -195,6 +195,21 @@ describe('nacl', () => {
 						Buffer.from(decryptedMessageBytes).toString('utf8'),
 					).to.be.eql(defaultMessage);
 				});
+
+				it('should throw an error with invalid message', () => {
+					return expect(
+						openBox.bind(
+							null,
+							Buffer.from(
+								'abcdef1234567890abcdef1234567890abcdef1234567890',
+								'hex',
+							),
+							Buffer.from(defaultNonce, 'hex'),
+							Buffer.from(defaultConvertedPublicKeyEd2Curve, 'hex'),
+							Buffer.from(defaultConvertedPrivateKeyEd2Curve, 'hex'),
+						),
+					).to.throw(Error, 'Failed to decrypt message');
+				});
 			});
 
 			describe('integration tests', () => {


### PR DESCRIPTION
### What was the problem?
After migration to typescript, there were small missing unit test

### How did I fix it?
Add unit tests and fix small issue

### How to test it?
`npm t`

### Review checklist

* The PR resolves #844 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
