### PR TITLE
Move constants to specific packages - Closes #785

### DIFF
--- a/packages/lisk-api-client/package.json
+++ b/packages/lisk-api-client/package.json
@@ -57,7 +57,6 @@
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
 	"dependencies": {
-		"@liskhq/lisk-constants": "1.1.1",
 		"axios": "0.18.0",
 		"verror": "1.10.0"
 	},

--- a/packages/lisk-api-client/src/api_client.ts
+++ b/packages/lisk-api-client/src/api_client.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { MAINNET_NETHASH, TESTNET_NETHASH } from '@liskhq/lisk-constants';
 import * as os from 'os';
 import { HashMap, InitOptions } from './api_types';
 import * as constants from './constants';
@@ -69,14 +68,14 @@ export class APIClient {
 
 	public static createMainnetAPIClient(options?: InitOptions): APIClient {
 		return new APIClient(constants.MAINNET_NODES, {
-			nethash: MAINNET_NETHASH,
+			nethash: constants.MAINNET_NETHASH,
 			...options,
 		});
 	}
 
 	public static createTestnetAPIClient(options?: InitOptions): APIClient {
 		return new APIClient(constants.TESTNET_NODES, {
-			nethash: TESTNET_NETHASH,
+			nethash: constants.TESTNET_NETHASH,
 			...options,
 		});
 	}

--- a/packages/lisk-api-client/src/constants.ts
+++ b/packages/lisk-api-client/src/constants.ts
@@ -16,7 +16,14 @@ export const GET = 'GET';
 export const POST = 'POST';
 export const PUT = 'PUT';
 
-export const TESTNET_NODES: ReadonlyArray<string> = ['https://testnet.lisk.io:443'];
+export const TESTNET_NETHASH =
+	'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba';
+export const MAINNET_NETHASH =
+	'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511';
+
+export const TESTNET_NODES: ReadonlyArray<string> = [
+	'https://testnet.lisk.io:443',
+];
 export const MAINNET_NODES: ReadonlyArray<string> = [
 	'https://node01.lisk.io:443',
 	'https://node02.lisk.io:443',
@@ -27,4 +34,3 @@ export const MAINNET_NODES: ReadonlyArray<string> = [
 	'https://node07.lisk.io:443',
 	'https://node08.lisk.io:443',
 ];
- 

--- a/packages/lisk-cryptography/package.json
+++ b/packages/lisk-cryptography/package.json
@@ -57,7 +57,6 @@
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
 	"dependencies": {
-		"@liskhq/lisk-constants": "1.1.1",
 		"browserify-bignum": "1.3.0-2",
 		"buffer-reverse": "1.0.1",
 		"ed2curve": "0.2.1",

--- a/packages/lisk-cryptography/src/constants.ts
+++ b/packages/lisk-cryptography/src/constants.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export const SIGNED_MESSAGE_PREFIX = 'Lisk Signed Message:\n';

--- a/packages/lisk-cryptography/src/sign.ts
+++ b/packages/lisk-cryptography/src/sign.ts
@@ -12,9 +12,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { SIGNED_MESSAGE_PREFIX } from '@liskhq/lisk-constants';
 import { encode as encodeVarInt } from 'varuint-bitcoin';
 import { bufferToHex, hexToBuffer } from './buffer';
+import { SIGNED_MESSAGE_PREFIX } from './constants';
 import { hash } from './hash';
 import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
 import {

--- a/packages/lisk-transactions/package.json
+++ b/packages/lisk-transactions/package.json
@@ -57,7 +57,6 @@
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
 	"dependencies": {
-		"@liskhq/lisk-constants": "1.1.1",
 		"@liskhq/lisk-cryptography": "1.1.1",
 		"ajv": "6.5.3",
 		"ajv-merge-patch": "4.1.0",

--- a/packages/lisk-transactions/src/constants.ts
+++ b/packages/lisk-transactions/src/constants.ts
@@ -40,7 +40,6 @@ export const BYTESIZES = {
 	DATA: 64,
 };
 
-// tslint:disable-next-line:no-magic-numbers
 export const EPOCH_TIME = new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0));
 export const EPOCH_TIME_MILLISECONDS = EPOCH_TIME.getTime();
 const MS_FACTOR = 1000;

--- a/packages/lisk-transactions/src/constants.ts
+++ b/packages/lisk-transactions/src/constants.ts
@@ -39,3 +39,18 @@ export const BYTESIZES = {
 	SECOND_SIGNATURE_TRANSACTION: 64,
 	DATA: 64,
 };
+
+// tslint:disable-next-line:no-magic-numbers
+export const EPOCH_TIME = new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0));
+export const EPOCH_TIME_MILLISECONDS = EPOCH_TIME.getTime();
+const MS_FACTOR = 1000;
+export const EPOCH_TIME_SECONDS = Math.floor(EPOCH_TIME.getTime() / MS_FACTOR);
+
+// Largest possible number which can be stored in eight bytes.
+// Derived from bignum.fromBuffer(Buffer.from(new Array(8).fill(255))).
+const MAX_EIGHT_BYTE_NUMBER = '18446744073709551615';
+
+export const MAX_ADDRESS_NUMBER = MAX_EIGHT_BYTE_NUMBER;
+export const MAX_TRANSACTION_ID = MAX_EIGHT_BYTE_NUMBER;
+// Largest possible amount. Maximum value for PostgreSQL bigint.
+export const MAX_TRANSACTION_AMOUNT = '9223372036854775807';

--- a/packages/lisk-transactions/src/utils/get_transaction_bytes.ts
+++ b/packages/lisk-transactions/src/utils/get_transaction_bytes.ts
@@ -12,10 +12,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { MAX_TRANSACTION_AMOUNT } from '@liskhq/lisk-constants';
 import cryptography from '@liskhq/lisk-cryptography';
 import BigNum from 'browserify-bignum';
-import { BYTESIZES } from '../constants';
+import { BYTESIZES, MAX_TRANSACTION_AMOUNT } from '../constants';
 import {
 	BaseTransaction,
 	DappAsset,

--- a/packages/lisk-transactions/src/utils/time.ts
+++ b/packages/lisk-transactions/src/utils/time.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { EPOCH_TIME_MILLISECONDS } from '@liskhq/lisk-constants';
+import { EPOCH_TIME_MILLISECONDS } from '../constants';
 
 const MS_TIME = 1000;
 

--- a/packages/lisk-transactions/src/utils/validation/validation.ts
+++ b/packages/lisk-transactions/src/utils/validation/validation.ts
@@ -12,14 +12,12 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import cryptography from '@liskhq/lisk-cryptography';
+import BigNum from 'browserify-bignum';
 import {
 	MAX_ADDRESS_NUMBER,
 	MAX_TRANSACTION_AMOUNT,
 	MAX_TRANSACTION_ID,
-} from '@liskhq/lisk-constants';
-import cryptography from '@liskhq/lisk-cryptography';
-import BigNum from 'browserify-bignum';
-import {
 	MULTISIGNATURE_MAX_KEYSGROUP,
 	MULTISIGNATURE_MIN_KEYSGROUP,
 } from '../../constants';


### PR DESCRIPTION
### What was the problem?
A lot of constants were in `lisk-constants` package but all of them were currently package specific constants.

### How did I fix it?
Move all the constants to the specific packages, but keep the `lisk-constants` as it is because it will
remove everything. 

### How to test it?
`npm t`

### Review checklist

* The PR resolves #785 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
