### PR TITLE
Remove default export from child packages and lisk-elements

### DIFF
--- a/packages/lisk-api-client/src/index.ts
+++ b/packages/lisk-api-client/src/index.ts
@@ -12,7 +12,4 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { APIClient } from './api_client';
-
-// tslint:disable-next-line no-default-export
-export default APIClient;
+export * from './api_client';

--- a/packages/lisk-api-client/test/index.ts
+++ b/packages/lisk-api-client/test/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import APIClient from '../src';
+import { APIClient } from '../src';
 import { expect } from 'chai';
 
 describe('api client', () => {

--- a/packages/lisk-client/src/index.ts
+++ b/packages/lisk-client/src/index.ts
@@ -12,11 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import APIClientModule from '@liskhq/lisk-api-client';
+import { APIClient as APIClientModule } from '@liskhq/lisk-api-client';
 import * as constantsModule from '@liskhq/lisk-constants';
-import cryptographyModule from '@liskhq/lisk-cryptography';
-import passphraseModule from '@liskhq/lisk-passphrase';
-import transactionModule from '@liskhq/lisk-transactions';
+import * as cryptographyModule from '@liskhq/lisk-cryptography';
+import * as passphraseModule from '@liskhq/lisk-passphrase';
+import * as transactionModule from '@liskhq/lisk-transactions';
 
 // tslint:disable-next-line variable-name
 export const APIClient = APIClientModule;

--- a/packages/lisk-cryptography/src/index.ts
+++ b/packages/lisk-cryptography/src/index.ts
@@ -12,19 +12,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import * as buffer from './buffer';
-import * as convert from './convert';
-import * as encrypt from './encrypt';
-import * as hash from './hash';
-import * as keys from './keys';
-import * as sign from './sign';
-
-// tslint:disable-next-line no-default-export
-export default {
-	...buffer,
-	...convert,
-	...encrypt,
-	...hash,
-	...keys,
-	...sign,
-};
+export * from './buffer';
+export * from './convert';
+export * from './encrypt';
+export * from './hash';
+export * from './keys';
+export * from './sign';

--- a/packages/lisk-cryptography/test/index.ts
+++ b/packages/lisk-cryptography/test/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '../src';
+import * as cryptography from '../src';
 import { expect } from 'chai';
 
 describe('cryptography index.js', () => {

--- a/packages/lisk-elements/src/index.ts
+++ b/packages/lisk-elements/src/index.ts
@@ -12,24 +12,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import APIClientModule from '@liskhq/lisk-api-client';
-import * as constantsModule from '@liskhq/lisk-constants';
-import cryptographyModule from '@liskhq/lisk-cryptography';
-import passphraseModule from '@liskhq/lisk-passphrase';
-import transactionModule from '@liskhq/lisk-transactions';
+import { APIClient } from '@liskhq/lisk-api-client';
+import * as constants from '@liskhq/lisk-constants';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as passphrase from '@liskhq/lisk-passphrase';
+import * as transaction from '@liskhq/lisk-transactions';
 
-// tslint:disable-next-line variable-name
-export const APIClient = APIClientModule;
-export const constants = constantsModule;
-export const cryptography = cryptographyModule;
-export const passphrase = passphraseModule;
-export const transaction = transactionModule;
-
-// tslint:disable-next-line no-default-export
-export default {
-	APIClient,
-	constants,
-	cryptography,
-	passphrase,
-	transaction,
-};
+export { APIClient, constants, cryptography, passphrase, transaction };

--- a/packages/lisk-passphrase/src/index.ts
+++ b/packages/lisk-passphrase/src/index.ts
@@ -15,8 +15,4 @@
 import Mnemonic from 'bip39';
 import * as validation from './validation';
 
-/* tslint:disable: no-default-export */
-export default {
-	Mnemonic,
-	validation,
-};
+export { Mnemonic, validation };

--- a/packages/lisk-passphrase/test/index.ts
+++ b/packages/lisk-passphrase/test/index.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import passphrase from '../src';
+import * as passphrase from '../src';
 
 describe('passphrase index.js', () => {
 	it('should export an object', () => {

--- a/packages/lisk-transactions/src/0_transfer.ts
+++ b/packages/lisk-transactions/src/0_transfer.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { BYTESIZES, TRANSFER_FEE } from './constants';
 import {
 	PartialTransaction,

--- a/packages/lisk-transactions/src/1_register_second_passphrase.ts
+++ b/packages/lisk-transactions/src/1_register_second_passphrase.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { SIGNATURE_FEE } from './constants';
 import {
 	PartialTransaction,

--- a/packages/lisk-transactions/src/3_cast_votes.ts
+++ b/packages/lisk-transactions/src/3_cast_votes.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { VOTE_FEE } from './constants';
 import { PartialTransaction, VoteTransaction } from './transaction_types';
 import {

--- a/packages/lisk-transactions/src/create_signature_object.ts
+++ b/packages/lisk-transactions/src/create_signature_object.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { BaseTransaction } from './transaction_types';
 import { multiSignTransaction, verifyTransaction } from './utils';
 

--- a/packages/lisk-transactions/src/index.ts
+++ b/packages/lisk-transactions/src/index.ts
@@ -22,8 +22,7 @@ import * as constants from './constants';
 import { createSignatureObject } from './create_signature_object';
 import * as utils from './utils';
 
-// tslint:disable-next-line no-default-export
-export default {
+export {
 	transfer,
 	registerSecondPassphrase,
 	registerDelegate,

--- a/packages/lisk-transactions/src/utils/get_address_and_public_key_from_recipient_data.ts
+++ b/packages/lisk-transactions/src/utils/get_address_and_public_key_from_recipient_data.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 
 interface RecipientIdAndPublicKey {
 	readonly recipientId: string;

--- a/packages/lisk-transactions/src/utils/get_transaction_bytes.ts
+++ b/packages/lisk-transactions/src/utils/get_transaction_bytes.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BigNum from 'browserify-bignum';
 import { BYTESIZES, MAX_TRANSACTION_AMOUNT } from '../constants';
 import {

--- a/packages/lisk-transactions/src/utils/get_transaction_hash.ts
+++ b/packages/lisk-transactions/src/utils/get_transaction_hash.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { BaseTransaction } from '../transaction_types';
 import { getTransactionBytes } from './get_transaction_bytes';
 

--- a/packages/lisk-transactions/src/utils/get_transaction_id.ts
+++ b/packages/lisk-transactions/src/utils/get_transaction_id.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { BaseTransaction } from '../transaction_types';
 import { getTransactionBytes } from './get_transaction_bytes';
 

--- a/packages/lisk-transactions/src/utils/prepare_transaction.ts
+++ b/packages/lisk-transactions/src/utils/prepare_transaction.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { BaseTransaction, PartialTransaction } from '../transaction_types';
 import { getTransactionId } from './get_transaction_id';
 import { signTransaction } from './sign_and_verify';

--- a/packages/lisk-transactions/src/utils/sign_and_verify.ts
+++ b/packages/lisk-transactions/src/utils/sign_and_verify.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { BaseTransaction } from '../transaction_types';
 import { getTransactionHash } from './get_transaction_hash';
 

--- a/packages/lisk-transactions/src/utils/sign_raw_transaction.ts
+++ b/packages/lisk-transactions/src/utils/sign_raw_transaction.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { BaseTransaction, PartialTransaction } from '../transaction_types';
 import { prepareTransaction } from './prepare_transaction';
 import { getTimeWithOffset } from './time';

--- a/packages/lisk-transactions/src/utils/validation/validation.ts
+++ b/packages/lisk-transactions/src/utils/validation/validation.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import BigNum from 'browserify-bignum';
 import {
 	MAX_ADDRESS_NUMBER,

--- a/packages/lisk-transactions/test/0_transfer.ts
+++ b/packages/lisk-transactions/test/0_transfer.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { transfer } from '../src/0_transfer';
 import { TransferTransaction } from '../src/transaction_types';
 import * as time from '../src/utils/time';

--- a/packages/lisk-transactions/test/4_register_multisignature_account.ts
+++ b/packages/lisk-transactions/test/4_register_multisignature_account.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { registerMultisignature } from '../src/4_register_multisignature_account';
 import {
 	MultiSignatureAsset,

--- a/packages/lisk-transactions/test/index.ts
+++ b/packages/lisk-transactions/test/index.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import transaction from '../src';
+import * as transaction from '../src';
 
 describe('transaction', () => {
 	describe('exports', () => {

--- a/packages/lisk-transactions/test/utils/get_transaction_id.ts
+++ b/packages/lisk-transactions/test/utils/get_transaction_id.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { getTransactionId } from '../../src/utils';
 import { BaseTransaction } from '../../src/transaction_types';
 // Require is used for stubbing

--- a/packages/lisk-transactions/test/utils/sign_and_verify.ts
+++ b/packages/lisk-transactions/test/utils/sign_and_verify.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import {
 	signTransaction,
 	multiSignTransaction,

--- a/packages/lisk-transactions/test/utils/validation/validation.ts
+++ b/packages/lisk-transactions/test/utils/validation/validation.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import cryptography from '@liskhq/lisk-cryptography';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { expect } from 'chai';
 import BigNum from 'browserify-bignum';
 import {


### PR DESCRIPTION
### What was the problem?
export default was not standard, and it was mainly for babel users.
Now it's in typescript, and the original main user was front-end, so we keep the functionality for client, but remove from all other packages.

### How did I fix it?
Remove default export from all the packages except `@liskhq/lisk-client`

### How to test it?
`npm test` or
`npm run build` and try to use each pakcages

### Review checklist

* The PR resolves #859 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
