### PR TITLE
Fix type definition for APIClient - Closes #863

### DIFF
--- a/packages/lisk-api-client/src/api_client.ts
+++ b/packages/lisk-api-client/src/api_client.ts
@@ -62,7 +62,7 @@ export interface ClientOptions {
 }
 
 export class APIClient {
-	public static get constants(): object {
+	public static get constants(): typeof constants {
 		return constants;
 	}
 

--- a/packages/lisk-api-client/src/api_method.ts
+++ b/packages/lisk-api-client/src/api_method.ts
@@ -29,7 +29,7 @@ export const apiMethod = (options: RequestConfig = {}): ApiHandler =>
 		this: Resource,
 		// tslint:disable-next-line readonly-array
 		...args: Array<number | string | object>
-	): Promise<ApiResponse | Error> {
+	): Promise<ApiResponse> {
 		const {
 			method = GET,
 			path = '',

--- a/packages/lisk-api-client/src/api_resource.ts
+++ b/packages/lisk-api-client/src/api_resource.ts
@@ -42,12 +42,12 @@ export class APIResource {
 		error: Error,
 		req: AxiosRequestConfig,
 		retryCount: number,
-	): Promise<ApiResponse | Error> {
+	): Promise<ApiResponse> {
 		if (this.apiClient.hasAvailableNodes()) {
-			return new Promise<ApiResponse | Error>(resolve =>
+			return new Promise<ApiResponse>(resolve =>
 				setTimeout(resolve, REQUEST_RETRY_TIMEOUT),
 			).then(
-				async (): Promise<ApiResponse | Error> => {
+				async (): Promise<ApiResponse> => {
 					if (retryCount > API_RECONNECT_MAX_RETRY_COUNT) {
 						throw error;
 					}
@@ -67,7 +67,7 @@ export class APIResource {
 		req: AxiosRequestConfig,
 		retry: boolean,
 		retryCount: number = 1,
-	): Promise<ApiResponse | Error> {
+	): Promise<ApiResponse> {
 		const request = Axios.request(req)
 			.then((res: AxiosResponse) => res.data)
 			.catch(

--- a/packages/lisk-api-client/src/api_types.ts
+++ b/packages/lisk-api-client/src/api_types.ts
@@ -16,7 +16,7 @@
 export type ApiHandler = (
 	// tslint:disable-next-line readonly-array
 	...args: Array<number | string | object>
-) => Promise<ApiResponse | Error>;
+) => Promise<ApiResponse>;
 
 export interface ApiResponse {
 	readonly data: unknown;
@@ -48,9 +48,6 @@ export interface RequestConfig {
 export interface Resource {
 	readonly headers: HashMap;
 	readonly path: string;
-	readonly request: (
-		data: object,
-		retry: boolean,
-	) => Promise<ApiResponse | Error>;
+	readonly request: (data: object, retry: boolean) => Promise<ApiResponse>;
 	readonly resourcePath: string;
 }


### PR DESCRIPTION
### What was the problem?
Define type for `APIClient.constants` and wrong type definition of `APIHandler`

### How did I fix it?
changed to concrete type, and remove resource from the type for APIHandler. 

### How to test it?
Check the built file and make sure it's typed correctly.

### Review checklist

* The PR resolves #863 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
