### PR TITLE
Add valid number of words to validate passphrase

### DIFF
--- a/packages/lisk-passphrase/src/validation.ts
+++ b/packages/lisk-passphrase/src/validation.ts
@@ -117,9 +117,9 @@ export const locateConsecutiveWhitespaces = (
 export const getPassphraseValidationErrors = (
 	passphrase: string,
 	wordlists?: ReadonlyArray<string>,
+	expectedWords: number = 12,
 ): ReadonlyArray<PassphraseError> => {
-	const expectedWords = 12;
-	const expectedWhitespaces = 11;
+	const expectedWhitespaces = expectedWords - 1;
 	const expectedUppercaseCharacterCount = 0;
 	const wordsInPassphrase = countPassphraseWords(passphrase);
 	const whiteSpacesInPassphrase = countPassphraseWhitespaces(passphrase);
@@ -170,7 +170,7 @@ export const getPassphraseValidationErrors = (
 			}
 			if (
 				error.code === whiteSpaceError.code &&
-				whiteSpacesInPassphrase > expectedWhitespaces
+				whiteSpacesInPassphrase !== expectedWhitespaces
 			) {
 				return [...errorArray, error];
 			}

--- a/packages/lisk-passphrase/test/validation.ts
+++ b/packages/lisk-passphrase/test/validation.ts
@@ -356,66 +356,83 @@ describe('passphrase validation', () => {
 			});
 		});
 
-		describe('given a passphrase with too many words', () => {
+		describe('given a passphrase with valid 15 words passphrase', () => {
 			const passphrase =
-				'model actor shallow eight glue upper seat lobster reason label enlist bridge actor';
+				'post dumb recycle buddy round normal scrap better people corn crystal again never shrimp kidney';
 
-			const passphraseTooManyWordsErrors = [
-				{
-					actual: 13,
-					code: 'INVALID_AMOUNT_OF_WORDS',
-					expected: 12,
-					message:
-						'Passphrase contains 13 words instead of expected 12. Please check the passphrase.',
-				},
-				{
-					actual: 12,
-					code: 'INVALID_AMOUNT_OF_WHITESPACES',
-					expected: 11,
-					location: [],
-					message:
-						'Passphrase contains 12 whitespaces instead of expected 11. Please check the passphrase.',
-				},
-				{
-					actual: false,
-					code: 'INVALID_MNEMONIC',
-					expected: true,
-					message:
-						'Passphrase is not a valid mnemonic passphrase. Please check the passphrase.',
-				},
-			];
-
-			it('should return the array with the errors', () => {
+			it('should return the array with the errors when validating with default expectedWords', () => {
+				const errors = [
+					{
+						actual: 15,
+						code: 'INVALID_AMOUNT_OF_WORDS',
+						expected: 12,
+						message:
+							'Passphrase contains 15 words instead of expected 12. Please check the passphrase.',
+					},
+					{
+						actual: 14,
+						code: 'INVALID_AMOUNT_OF_WHITESPACES',
+						expected: 11,
+						location: [],
+						message:
+							'Passphrase contains 14 whitespaces instead of expected 11. Please check the passphrase.',
+					},
+				];
 				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
-					passphraseTooManyWordsErrors,
+					errors,
 				);
 			});
-		});
 
-		describe('given a passphrase with too few words', () => {
-			const passphrase =
-				'model actor shallow eight glue upper seat lobster reason label enlist';
-			const passphraseTooFewWordsErrors = [
-				{
-					actual: 11,
-					code: 'INVALID_AMOUNT_OF_WORDS',
-					expected: 12,
-					message:
-						'Passphrase contains 11 words instead of expected 12. Please check the passphrase.',
-				},
-				{
-					actual: false,
-					code: 'INVALID_MNEMONIC',
-					expected: true,
-					message:
-						'Passphrase is not a valid mnemonic passphrase. Please check the passphrase.',
-				},
-			];
+			it('should return the array with the errors when validating with lower expectedWords', () => {
+				const errors = [
+					{
+						actual: 15,
+						code: 'INVALID_AMOUNT_OF_WORDS',
+						expected: 12,
+						message:
+							'Passphrase contains 15 words instead of expected 12. Please check the passphrase.',
+					},
+					{
+						actual: 14,
+						code: 'INVALID_AMOUNT_OF_WHITESPACES',
+						expected: 11,
+						location: [],
+						message:
+							'Passphrase contains 14 whitespaces instead of expected 11. Please check the passphrase.',
+					},
+				];
+				return expect(
+					getPassphraseValidationErrors(passphrase, undefined, 12),
+				).to.be.eql(errors);
+			});
 
-			it('should return the array with the errors', () => {
-				return expect(getPassphraseValidationErrors(passphrase)).to.be.eql(
-					passphraseTooFewWordsErrors,
-				);
+			it('should return the array with the errors when validating with higher expectedWords', () => {
+				const errors = [
+					{
+						actual: 15,
+						code: 'INVALID_AMOUNT_OF_WORDS',
+						expected: 18,
+						message:
+							'Passphrase contains 15 words instead of expected 18. Please check the passphrase.',
+					},
+					{
+						actual: 14,
+						code: 'INVALID_AMOUNT_OF_WHITESPACES',
+						expected: 17,
+						location: [],
+						message:
+							'Passphrase contains 14 whitespaces instead of expected 17. Please check the passphrase.',
+					},
+				];
+				return expect(
+					getPassphraseValidationErrors(passphrase, undefined, 18),
+				).to.be.eql(errors);
+			});
+
+			it('should return an empty array when validating with exact expectedWords', () => {
+				return expect(
+					getPassphraseValidationErrors(passphrase, undefined, 15),
+				).to.be.eql([]);
 			});
 		});
 

--- a/packages/lisk-passphrase/test/validation.ts
+++ b/packages/lisk-passphrase/test/validation.ts
@@ -360,7 +360,7 @@ describe('passphrase validation', () => {
 			const passphrase =
 				'post dumb recycle buddy round normal scrap better people corn crystal again never shrimp kidney';
 
-			it('should return the array with the errors when validating with default expectedWords', () => {
+			it('should return an array with the errors when validating with default expectedWords', () => {
 				const errors = [
 					{
 						actual: 15,
@@ -383,7 +383,7 @@ describe('passphrase validation', () => {
 				);
 			});
 
-			it('should return the array with the errors when validating with lower expectedWords', () => {
+			it('should return an array with the errors when validating with lower expectedWords', () => {
 				const errors = [
 					{
 						actual: 15,
@@ -406,7 +406,7 @@ describe('passphrase validation', () => {
 				).to.be.eql(errors);
 			});
 
-			it('should return the array with the errors when validating with higher expectedWords', () => {
+			it('should return an array with the errors when validating with higher expectedWords', () => {
 				const errors = [
 					{
 						actual: 15,
@@ -425,7 +425,11 @@ describe('passphrase validation', () => {
 					},
 				];
 				return expect(
-					getPassphraseValidationErrors(passphrase, undefined, 18),
+					getPassphraseValidationErrors(
+						passphrase,
+						Mnemonic.wordlists.english,
+						18,
+					),
 				).to.be.eql(errors);
 			});
 


### PR DESCRIPTION
### What was the problem?
Validating passphrase was limited to exactly 12 words.

### How did I fix it?
Add another input field to adjust expected words count

### How to test it?
`npm t`
or
```
passphrase.getPassphraseValidationErrors('post dumb recycle buddy round normal scrap better people corn crystal again never shrimp kidney') // this should be error
passphrase.getPassphraseValidationErrors('post dumb recycle buddy round normal scrap better people corn crystal again never shrimp kidney', undefined, 15)
```

### Review checklist

* The PR resolves #862 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
