### PR TITLE
Expose constants from lisk-cryptography - Closes #906

### DIFF
--- a/packages/lisk-cryptography/src/index.ts
+++ b/packages/lisk-cryptography/src/index.ts
@@ -12,9 +12,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import * as constants from './constants';
+
 export * from './buffer';
 export * from './convert';
 export * from './encrypt';
 export * from './hash';
 export * from './keys';
 export * from './sign';
+
+export { constants };


### PR DESCRIPTION
### What was the problem?
Cryptography module constants were not exposed

### How did I fix it?
Expose constants from cryptography index.ts

### How to test it?
```
cd packages/lisk-client
npm start
lisk.cryptography.constants
```
### Review checklist

* The PR resolves #906 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
