### PR TITLE
Extend APIError to have errors from core

### DIFF
--- a/packages/lisk-api-client/src/api_method.ts
+++ b/packages/lisk-api-client/src/api_method.ts
@@ -14,8 +14,8 @@
  */
 import { AxiosRequestConfig } from 'axios';
 import {
-	ApiHandler,
-	ApiResponse,
+	APIHandler,
+	APIResponse,
 	HashMap,
 	RequestConfig,
 	Resource,
@@ -24,12 +24,12 @@ import { GET } from './constants';
 import { solveURLParams, toQueryString } from './utils';
 
 // Bind to resource class
-export const apiMethod = (options: RequestConfig = {}): ApiHandler =>
+export const apiMethod = (options: RequestConfig = {}): APIHandler =>
 	async function apiHandler(
 		this: Resource,
 		// tslint:disable-next-line readonly-array
 		...args: Array<number | string | object>
-	): Promise<ApiResponse> {
+	): Promise<APIResponse> {
 		const {
 			method = GET,
 			path = '',

--- a/packages/lisk-api-client/src/api_types.ts
+++ b/packages/lisk-api-client/src/api_types.ts
@@ -13,7 +13,7 @@
  *
  */
 /* tslint:disable no-mixed-interface */
-export type ApiHandler = (
+export type APIHandler = (
 	// tslint:disable-next-line readonly-array
 	...args: Array<number | string | object>
 ) => Promise<APIResponse>;

--- a/packages/lisk-api-client/src/api_types.ts
+++ b/packages/lisk-api-client/src/api_types.ts
@@ -16,12 +16,23 @@
 export type ApiHandler = (
 	// tslint:disable-next-line readonly-array
 	...args: Array<number | string | object>
-) => Promise<ApiResponse>;
+) => Promise<APIResponse>;
 
-export interface ApiResponse {
+export interface APIResponse {
 	readonly data: unknown;
 	readonly links: object;
 	readonly meta: object;
+}
+
+export interface APIErrorResponse {
+	readonly error?: string;
+	readonly errors?: ReadonlyArray<APIErrorContents>;
+	readonly message?: string;
+}
+
+export interface APIErrorContents {
+	readonly code?: string;
+	readonly message?: string;
 }
 
 export interface HashMap {
@@ -48,6 +59,6 @@ export interface RequestConfig {
 export interface Resource {
 	readonly headers: HashMap;
 	readonly path: string;
-	readonly request: (data: object, retry: boolean) => Promise<ApiResponse>;
+	readonly request: (data: object, retry: boolean) => Promise<APIResponse>;
 	readonly resourcePath: string;
 }

--- a/packages/lisk-api-client/src/errors.ts
+++ b/packages/lisk-api-client/src/errors.ts
@@ -2,11 +2,23 @@ import { VError } from 'verror';
 
 const defaultErrorNo = 500;
 
+export interface APIErrorData {
+	readonly code?: string;
+	readonly message?: string;
+}
+
 export class APIError extends VError {
-	public errno?: number;
-	public constructor(message?: string, errno?: number) {
-		super(message || '');
-		this.name = 'API Error';
-		this.errno = errno || defaultErrorNo;
+	public errno: number;
+	public errors?: ReadonlyArray<APIErrorData>;
+
+	public constructor(
+		message: string = '',
+		errno: number = defaultErrorNo,
+		errors?: ReadonlyArray<APIErrorData>,
+	) {
+		super(message);
+		this.name = 'APIError';
+		this.errno = errno;
+		this.errors = errors;
 	}
 }

--- a/packages/lisk-api-client/src/resources/accounts.ts
+++ b/packages/lisk-api-client/src/resources/accounts.ts
@@ -15,13 +15,13 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET } from '../constants';
 
 export class AccountsResource extends APIResource {
-	public get: ApiHandler;
-	public getMultisignatureGroups: ApiHandler;
-	public getMultisignatureMemberships: ApiHandler;
+	public get: APIHandler;
+	public getMultisignatureGroups: APIHandler;
+	public getMultisignatureMemberships: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/src/resources/blocks.ts
+++ b/packages/lisk-api-client/src/resources/blocks.ts
@@ -15,11 +15,11 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET } from '../constants';
 
 export class BlocksResource extends APIResource {
-	public get: ApiHandler;
+	public get: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/src/resources/dapps.ts
+++ b/packages/lisk-api-client/src/resources/dapps.ts
@@ -15,11 +15,11 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET } from '../constants';
 
 export class DappsResource extends APIResource {
-	public get: ApiHandler;
+	public get: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/src/resources/delegates.ts
+++ b/packages/lisk-api-client/src/resources/delegates.ts
@@ -15,14 +15,14 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET } from '../constants';
 
 export class DelegatesResource extends APIResource {
-	public get: ApiHandler;
-	public getForgers: ApiHandler;
-	public getForgingStatistics: ApiHandler;
-	public getStandby: ApiHandler;
+	public get: APIHandler;
+	public getForgers: APIHandler;
+	public getForgingStatistics: APIHandler;
+	public getStandby: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/src/resources/node.ts
+++ b/packages/lisk-api-client/src/resources/node.ts
@@ -15,16 +15,16 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET, PUT } from '../constants';
 
 export class NodeResource extends APIResource {
-	public getConstants: ApiHandler;
-	public getForgingStatus: ApiHandler;
-	public getStatus: ApiHandler;
-	public getTransactions: ApiHandler;
+	public getConstants: APIHandler;
+	public getForgingStatus: APIHandler;
+	public getStatus: APIHandler;
+	public getTransactions: APIHandler;
 	public path: string;
-	public updateForgingStatus: ApiHandler;
+	public updateForgingStatus: APIHandler;
 
 	public constructor(apiClient: APIClient) {
 		super(apiClient);

--- a/packages/lisk-api-client/src/resources/peers.ts
+++ b/packages/lisk-api-client/src/resources/peers.ts
@@ -15,11 +15,11 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET } from '../constants';
 
 export class PeersResource extends APIResource {
-	public get: ApiHandler;
+	public get: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/src/resources/signatures.ts
+++ b/packages/lisk-api-client/src/resources/signatures.ts
@@ -15,11 +15,11 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { POST } from '../constants';
 
 export class SignaturesResource extends APIResource {
-	public broadcast: ApiHandler;
+	public broadcast: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/src/resources/transactions.ts
+++ b/packages/lisk-api-client/src/resources/transactions.ts
@@ -15,12 +15,12 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET, POST } from '../constants';
 
 export class TransactionsResource extends APIResource {
-	public broadcast: ApiHandler;
-	public get: ApiHandler;
+	public broadcast: APIHandler;
+	public get: APIHandler;
 	public path: string;
 	public constructor(apiClient: APIClient) {
 		super(apiClient);

--- a/packages/lisk-api-client/src/resources/voters.ts
+++ b/packages/lisk-api-client/src/resources/voters.ts
@@ -15,11 +15,11 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET } from '../constants';
 
 export class VotersResource extends APIResource {
-	public get: ApiHandler;
+	public get: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/src/resources/votes.ts
+++ b/packages/lisk-api-client/src/resources/votes.ts
@@ -15,11 +15,11 @@
 import { APIClient } from '../api_client';
 import { apiMethod } from '../api_method';
 import { APIResource } from '../api_resource';
-import { ApiHandler } from '../api_types';
+import { APIHandler } from '../api_types';
 import { GET } from '../constants';
 
 export class VotesResource extends APIResource {
-	public get: ApiHandler;
+	public get: APIHandler;
 	public path: string;
 
 	public constructor(apiClient: APIClient) {

--- a/packages/lisk-api-client/test/api_method.ts
+++ b/packages/lisk-api-client/test/api_method.ts
@@ -14,7 +14,7 @@
  */
 import { expect } from 'chai';
 import { apiMethod } from '../src/api_method';
-import { Resource, ApiHandler } from '../src/api_types';
+import { Resource, APIHandler } from '../src/api_types';
 
 describe('API method module', () => {
 	const GET = 'GET';
@@ -36,7 +36,7 @@ describe('API method module', () => {
 	const secondURLParam = 123;
 	let resource: Resource;
 	let requestResult: object;
-	let handler: ApiHandler;
+	let handler: APIHandler;
 	let validationError: Error;
 
 	beforeEach(() => {

--- a/packages/lisk-api-client/test/api_resource.ts
+++ b/packages/lisk-api-client/test/api_resource.ts
@@ -135,7 +135,7 @@ describe('API resource module', () => {
 				});
 
 				return resource.request(defaultRequest, false).catch(err => {
-					return expect(err.message).to.equal('An unknown error has occurred.');
+					return expect(err.errno).to.equal(statusCode);
 				});
 			});
 
@@ -183,7 +183,7 @@ describe('API resource module', () => {
 			});
 
 			it('should reject with error message from server if message is undefined and error is supplied', () => {
-				const serverErrorMessage = 'validation error';
+				const serverErrorMessage = 'error from server';
 				const statusCode = 300;
 				requestStub.rejects({
 					response: {

--- a/packages/lisk-api-client/test/api_resource.ts
+++ b/packages/lisk-api-client/test/api_resource.ts
@@ -45,7 +45,7 @@ describe('API resource module', () => {
 		limit: 0,
 	};
 
-	interface FakeApiClient {
+	interface FakeAPIClient {
 		headers: object;
 		currentNode: string;
 		hasAvailableNodes: () => boolean | void;
@@ -54,7 +54,7 @@ describe('API resource module', () => {
 	}
 
 	let resource: APIResource;
-	let apiClient: FakeApiClient;
+	let apiClient: FakeAPIClient;
 
 	beforeEach(() => {
 		apiClient = {

--- a/packages/lisk-api-client/test/api_resource.ts
+++ b/packages/lisk-api-client/test/api_resource.ts
@@ -125,6 +125,34 @@ describe('API resource module', () => {
 		});
 
 		describe('when response status is greater than 300', () => {
+			it('should reject with errno if status code is supplied', () => {
+				const statusCode = 300;
+				requestStub.rejects({
+					response: {
+						status: statusCode,
+						data: undefined,
+					},
+				});
+
+				return resource.request(defaultRequest, false).catch(err => {
+					return expect(err.message).to.equal('An unknown error has occurred.');
+				});
+			});
+
+			it('should reject with "An unknown error has occured." message if there is no data is supplied', () => {
+				const statusCode = 300;
+				requestStub.rejects({
+					response: {
+						status: statusCode,
+						data: undefined,
+					},
+				});
+
+				return resource.request(defaultRequest, false).catch(err => {
+					return expect(err.message).to.equal('An unknown error has occurred.');
+				});
+			});
+
 			it('should reject with "An unknown error has occured." message if there is no message is supplied', () => {
 				const statusCode = 300;
 				requestStub.rejects({
@@ -135,9 +163,7 @@ describe('API resource module', () => {
 				});
 
 				return resource.request(defaultRequest, false).catch(err => {
-					return expect(err.message).to.equal(
-						`Status ${statusCode} : An unknown error has occurred.`,
-					);
+					return expect(err.message).to.equal('An unknown error has occurred.');
 				});
 			});
 
@@ -152,9 +178,47 @@ describe('API resource module', () => {
 				});
 
 				return resource.request(defaultRequest, false).catch(err => {
-					return expect(err.message).to.eql(
-						`Status ${statusCode} : ${serverErrorMessage}`,
-					);
+					return expect(err.message).to.eql(serverErrorMessage);
+				});
+			});
+
+			it('should reject with error message from server if message is undefined and error is supplied', () => {
+				const serverErrorMessage = 'validation error';
+				const statusCode = 300;
+				requestStub.rejects({
+					response: {
+						status: statusCode,
+						data: { message: undefined, error: serverErrorMessage },
+					},
+				});
+
+				return resource.request(defaultRequest, false).catch(err => {
+					return expect(err.message).to.eql(serverErrorMessage);
+				});
+			});
+
+			it('should reject with errors from server if errors are supplied', () => {
+				const serverErrorMessage = 'validation error';
+				const statusCode = 300;
+				const errors = [
+					{
+						code: 'error_code_1',
+						message: 'message1',
+					},
+					{
+						code: 'error_code_2',
+						message: 'message2',
+					},
+				];
+				requestStub.rejects({
+					response: {
+						status: statusCode,
+						data: { message: serverErrorMessage, errors },
+					},
+				});
+
+				return resource.request(defaultRequest, false).catch(err => {
+					return expect(err.errors).to.eql(errors);
 				});
 			});
 

--- a/packages/lisk-api-client/test/errors.ts
+++ b/packages/lisk-api-client/test/errors.ts
@@ -13,16 +13,15 @@
  *
  */
 import { expect } from 'chai';
-import { APIError } from '../src/errors';
+import { APIError, APIErrorData } from '../src/errors';
 
 describe('api errors module', () => {
 	let apiError: APIError;
 	const defaultMessage = 'this is an error';
 	const defaultErrno = 401;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		apiError = new APIError();
-		return Promise.resolve();
 	});
 
 	describe('#constructor', () => {
@@ -32,8 +31,8 @@ describe('api errors module', () => {
 				.and.be.instanceof(APIError);
 		});
 
-		it('should set error name to `API Error`', () => {
-			return expect(apiError.name).to.eql('API Error');
+		it('should set error name to `APIError`', () => {
+			return expect(apiError.name).to.eql('APIError');
 		});
 
 		it('should set error message to empty string by default', () => {
@@ -44,7 +43,7 @@ describe('api errors module', () => {
 			return expect(apiError.errno).to.eql(500);
 		});
 
-		describe('when passed arguments', () => {
+		describe('when passed errno', () => {
 			beforeEach(() => {
 				apiError = new APIError(defaultMessage, defaultErrno);
 				return Promise.resolve();
@@ -56,6 +55,39 @@ describe('api errors module', () => {
 
 			it('should set errno when passed through second argument', () => {
 				return expect(apiError.errno).to.eql(defaultErrno);
+			});
+		});
+
+		describe('when passed errno and errors', () => {
+			const errors = [
+				{
+					code: 'error_code_1',
+					message: 'message1',
+				},
+				{
+					code: 'error_code_2',
+					message: 'message2',
+				},
+			];
+
+			beforeEach(() => {
+				apiError = new APIError(defaultMessage, defaultErrno, errors);
+				return Promise.resolve();
+			});
+
+			it('should set error message when passed through first argument', () => {
+				return expect(apiError.message).to.eql(defaultMessage);
+			});
+
+			it('should set errno when passed through second argument', () => {
+				return expect(apiError.errno).to.eql(defaultErrno);
+			});
+
+			it('should set errors when passed through third argument', () => {
+				expect(apiError.errors).to.have.lengthOf(2);
+				const errorData = apiError.errors as ReadonlyArray<APIErrorData>;
+				expect(errorData[0].code).to.equal(errors[0].code);
+				return expect(errorData[0].message).to.equal(errors[0].message);
 			});
 		});
 	});

--- a/packages/lisk-api-client/test/errors.ts
+++ b/packages/lisk-api-client/test/errors.ts
@@ -20,8 +20,9 @@ describe('api errors module', () => {
 	const defaultMessage = 'this is an error';
 	const defaultErrno = 401;
 
-	beforeEach(async () => {
+	beforeEach(() => {
 		apiError = new APIError();
+		return Promise.resolve();
 	});
 
 	describe('#constructor', () => {


### PR DESCRIPTION
### What was the problem?
APIError did not have enough information to show proper error on the user side.

### How did I fix it?
Add `errors` from APIResponse if exists in the error.

### How to test it?
```
cd packages/lisk-client
npm start
client = lisk.APIClient.createTestnetAPIClient()
client.votes.get({ "random": 1 }).catch((err) => console.log(err.message))
client.votes.get({ "random": 1 }).catch((err) => console.log(err.errno))
client.votes.get({ "random": 1 }).catch((err) => console.log(err.errors))

```

### Review checklist
* ~~Merge After #914~~
* The PR resolves #916 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
