### PR TITLE
Select peers doesn't always give 'n' requested peers - Closes#925

### DIFF
--- a/packages/lisk-p2p/src/peer_selector.ts
+++ b/packages/lisk-p2p/src/peer_selector.ts
@@ -96,26 +96,24 @@ export const selectPeers = (
 		return goodPeer;
 	}
 
-	const selectedPeersList = Array(numOfPeers)
-		.fill(0)
-		.reduce(
-			peerObject => {
-				const index = Math.floor(
-					Math.random() * peerObject.processedPeers.length,
-				);
-				const peer = peerObject.processedPeers[index];
-				// This will ensure that the selected peer is not choosen again by the random function above
-				const tempProcessedPeers = peerObject.processedPeers.filter(
-					(findPeer: Peer) => findPeer !== peer,
-				);
+	const { peerList } = new Array(numOfPeers).fill(0).reduce(
+		peerListObject => {
+			const index = Math.floor(
+				Math.random() * peerListObject.processedPeersArray.length,
+			);
+			const peer = peerListObject.processedPeersArray[index];
+			// This will ensure that the selected peer is not choosen again by the random function above
+			const tempProcessedPeers = peerListObject.processedPeersArray.filter(
+				(findPeer: Peer) => findPeer !== peer,
+			);
 
-				return {
-					peerList: [...peerObject.peerList, peer],
-					processedPeers: tempProcessedPeers,
-				};
-			},
-			{ peerList: [], processedPeers },
-		);
+			return {
+				peerList: [...peerListObject.peerList, peer],
+				processedPeersArray: tempProcessedPeers,
+			};
+		},
+		{ peerList: [], processedPeersArray: processedPeers },
+	);
 
-	return selectedPeersList.peerList;
+	return peerList;
 };

--- a/packages/lisk-p2p/src/peer_selector.ts
+++ b/packages/lisk-p2p/src/peer_selector.ts
@@ -67,9 +67,9 @@ export const selectPeers = (
 	const processedPeers = sortedPeers.filter(
 		peer =>
 			peer &&
-			Math.abs(
-				(calculatedHistogramValues ? calculatedHistogramValues.height : 0) -
-					peer.height) < aggregation + 1);
+			Math.abs(calculatedHistogramValues.height - peer.height) <
+				aggregation + 1,
+	);
 
 	if (numOfPeers <= 0) {
 		return processedPeers;
@@ -98,16 +98,24 @@ export const selectPeers = (
 
 	const selectedPeersList = Array(numOfPeers)
 		.fill(0)
-		.reduce((peerList: ReadonlyArray<Peer>) => {
-			const peer =
-				processedPeers[Math.floor(Math.random() * processedPeers.length)];
+		.reduce(
+			peerObject => {
+				const index = Math.floor(
+					Math.random() * peerObject.processedPeers.length,
+				);
+				const peer = processedPeers[index];
+				// This will ensure that the selected peer is not choosen again by the random function above
+				const tempProcessedPeers = peerObject.processedPeers.filter(
+					(findPeer: Peer) => findPeer !== peer,
+				);
 
-			if (peerList.includes(peer)) {
-				return peerList;
-			}
+				return {
+					peerList: [...peerObject.peerList, peer],
+					processedPeers: tempProcessedPeers,
+				};
+			},
+			{ peerList: [], processedPeers },
+		);
 
-			return [...peerList, peer];
-		}, []);
-
-	return selectedPeersList;
+	return selectedPeersList.peerList;
 };

--- a/packages/lisk-p2p/src/peer_selector.ts
+++ b/packages/lisk-p2p/src/peer_selector.ts
@@ -103,7 +103,7 @@ export const selectPeers = (
 				const index = Math.floor(
 					Math.random() * peerObject.processedPeers.length,
 				);
-				const peer = processedPeers[index];
+				const peer = peerObject.processedPeers[index];
 				// This will ensure that the selected peer is not choosen again by the random function above
 				const tempProcessedPeers = peerObject.processedPeers.filter(
 					(findPeer: Peer) => findPeer !== peer,

--- a/packages/lisk-p2p/test/unit/peer_selector.ts
+++ b/packages/lisk-p2p/test/unit/peer_selector.ts
@@ -19,7 +19,7 @@ import { PeerOptions, selectPeers } from '../../src/peer_selector';
 describe('peer selector', () => {
 	describe('#selectPeer', () => {
 		let peerList = initializePeerList();
-		const option: PeerOptions = {
+		const selectionParams: PeerOptions = {
 			lastBlockHeight: 545777,
 			netHash: '73458irc3yb7rg37r7326dbt7236',
 		};
@@ -52,54 +52,60 @@ describe('peer selector', () => {
 				peerList = initializePeerList();
 			});
 
+			it('should return an array without optional arguments', () => {
+				return expect(selectPeers(peerList)).to.be.an('array');
+			});
+
 			it('should return an array', () => {
-				return expect(selectPeers(peerList, option)).to.be.an('array');
+				return expect(selectPeers(peerList, selectionParams)).to.be.an('array');
 			});
 
 			it('returned array should contain good peers according to algorithm', () => {
-				return expect(selectPeers(peerList, option))
+				return expect(selectPeers(peerList, selectionParams))
 					.and.be.an('array')
 					.and.to.be.eql(goodPeers);
 			});
 
 			it('return empty peer list for no peers as an argument', () => {
-				return expect(selectPeers([], option))
+				return expect(selectPeers([], selectionParams))
 					.and.be.an('array')
 					.and.to.be.eql([]);
 			});
 
 			it('should return an array having one good peer', () => {
-				return expect(selectPeers(peerList, option, 1))
+				return expect(selectPeers(peerList, selectionParams, 1))
 					.and.be.an('array')
 					.and.of.length(1);
 			});
 
 			it('should return an array having 2 good peers', () => {
-				return expect(selectPeers(peerList, option, 2))
+				return expect(selectPeers(peerList, selectionParams, 2))
 					.and.be.an('array')
 					.and.of.length(2);
 			});
 
 			it('should return an array having all good peers', () => {
-				return expect(selectPeers(peerList, option, 0))
+				return expect(selectPeers(peerList, selectionParams, 0))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('should return an array having all good peers ignoring requested negative number of peers', () => {
-				return expect(selectPeers(peerList, option, -1))
+				return expect(selectPeers(peerList, selectionParams, -1))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('should return an array of equal length equal to requested number of peers', () => {
-				return expect(selectPeers(peerList, option, 3))
+				return expect(selectPeers(peerList, selectionParams, 3))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('should throw an error when requested peers are greater than available good peers', () => {
-				return expect(selectPeers.bind(selectPeers, peerList, option, 4))
+				return expect(
+					selectPeers.bind(selectPeers, peerList, selectionParams, 4),
+				)
 					.to.throw(
 						`Requested number of peers: '4' is more than the available number of good peers: '3'`,
 					)
@@ -113,11 +119,11 @@ describe('peer selector', () => {
 				peerList = initializePeerList();
 			});
 			const lowHeightPeers = peerList.filter(
-				peer => peer.height < option.lastBlockHeight,
+				peer => peer.height < selectionParams.lastBlockHeight,
 			);
 
 			it('should return an array with 0 good peers', () => {
-				return expect(selectPeers(lowHeightPeers, option, 2))
+				return expect(selectPeers(lowHeightPeers, selectionParams, 2))
 					.and.be.an('array')
 					.and.of.length(0);
 			});


### PR DESCRIPTION
### What was the problem?

Sometimes peer selection algorithm is not returning the requested `n` number of peers.

### How did I fix it?

Improved selection peer algorithm in the section where we were handling `n` number of requested peers.

### How to test it?

Run `npm t` multiple times, it will not fail now.

### Review checklist

* The PR resolves #925 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
