### PR TITLE
Add type definition for socketcluster

### DIFF
--- a/packages/lisk-p2p/test/tsconfig.json
+++ b/packages/lisk-p2p/test/tsconfig.json
@@ -1,1 +1,10 @@
-../../../templates/tsconfig-test.json.tmpl
+{
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"baseUrl": ".",
+		"declaration": false,
+		"target": "es2017",
+		"typeRoots": ["../types", "../../../types", "../node_modules/@types"]
+	},
+	"include": ["../../../types/**/*", "./**/*"]
+}

--- a/packages/lisk-p2p/tsconfig.json
+++ b/packages/lisk-p2p/tsconfig.json
@@ -1,1 +1,9 @@
-../../templates/tsconfig.json.tmpl
+{
+	"extends": "../../tsconfig",
+	"compilerOptions": {
+		"declaration": true,
+		"outDir": "dist-node",
+		"rootDir": "./src"
+	},
+	"include": ["../../types/**/*", "types/**/*", "src/**/*"]
+}

--- a/packages/lisk-p2p/types/socketcluster-client/index.d.ts
+++ b/packages/lisk-p2p/types/socketcluster-client/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'socketcluster-client' {
+	const socketClusterClient: any;
+	export = socketClusterClient;
+}

--- a/packages/lisk-p2p/types/socketcluster-server/index.d.ts
+++ b/packages/lisk-p2p/types/socketcluster-server/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'socketcluster-server' {
+	const socketClusterServer: any;
+	export = socketClusterServer;
+}


### PR DESCRIPTION
### What was the problem?

Socket-cluster doesn't have official type definition so define minimal type definition for socket cluster server needed.

### How did I fix it?

Add type definition file under `types` folder for `socketcluster-server` and `socketcluster-client`

### How to test it?

`npm run build` 
`npm t`

### Review checklist

* The PR resolves #918
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
