### PR TITLE
Disable esModuleInterop setting - Closes #993

### DIFF
--- a/packages/lisk-api-client/src/resources/index.ts
+++ b/packages/lisk-api-client/src/resources/index.ts
@@ -12,13 +12,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as AccountsResource } from './accounts';
-export { default as BlocksResource } from './blocks';
-export { default as DappsResource } from './dapps';
-export { default as DelegatesResource } from './delegates';
-export { default as NodeResource } from './node';
-export { default as PeersResource } from './peers';
-export { default as SignaturesResource } from './signatures';
-export { default as TransactionsResource } from './transactions';
-export { default as VotersResource } from './voters';
-export { default as VotesResource } from './votes';
+export { AccountsResource } from './accounts';
+export { BlocksResource } from './blocks';
+export { DappsResource } from './dapps';
+export { DelegatesResource } from './delegates';
+export { NodeResource } from './node';
+export { PeersResource } from './peers';
+export { SignaturesResource } from './signatures';
+export { TransactionsResource } from './transactions';
+export { VotersResource } from './voters';
+export { VotesResource } from './votes';

--- a/packages/lisk-api-client/test/_setup.ts
+++ b/packages/lisk-api-client/test/_setup.ts
@@ -12,11 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import 'chai/register-expect';
-import sinonChai from 'sinon-chai';
-import sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
 
 process.env.NODE_ENV = 'test';
 

--- a/packages/lisk-api-client/test/api_client.ts
+++ b/packages/lisk-api-client/test/api_client.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import os from 'os';
+import * as os from 'os';
 import { APIClient } from '../src/api_client';
 
 describe('APIClient module', () => {

--- a/packages/lisk-api-client/test/api_resource.ts
+++ b/packages/lisk-api-client/test/api_resource.ts
@@ -15,7 +15,7 @@
 import { expect } from 'chai';
 import { APIClient } from '../src/api_client';
 import { APIResource } from '../src/api_resource';
-import sinon from 'sinon';
+import * as sinon from 'sinon';
 // Required for stub
 const axios = require('axios');
 

--- a/packages/lisk-cryptography/src/buffer.ts
+++ b/packages/lisk-cryptography/src/buffer.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 
 export const bigNumberToBuffer = (bignumber: string, size: number) =>
 	new BigNum(bignumber).toBuffer({ size, endian: 'big' });

--- a/packages/lisk-cryptography/src/convert.ts
+++ b/packages/lisk-cryptography/src/convert.ts
@@ -12,9 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import reverseBuffer from 'buffer-reverse';
-import ed2curve from 'ed2curve';
-import querystring from 'querystring';
+// Required because first level function export
+// tslint:disable-next-line no-require-imports
+import reverse = require('buffer-reverse');
+import * as ed2curve from 'ed2curve';
+import * as querystring from 'querystring';
 import { bufferToBigNumberString } from './buffer';
 import { EncryptedPassphraseObject } from './encrypt';
 import { hash } from './hash';
@@ -24,10 +26,10 @@ export const getFirstEightBytesReversed = (input: string | Buffer): Buffer => {
 	// Union type arguments on overloaded functions do not work in typescript.
 	// Relevant discussion: https://github.com/Microsoft/TypeScript/issues/23155
 	if (typeof input === 'string') {
-		return reverseBuffer(Buffer.from(input).slice(0, BUFFER_SIZE));
+		return reverse(Buffer.from(input).slice(0, BUFFER_SIZE));
 	}
 
-	return reverseBuffer(Buffer.from(input).slice(0, BUFFER_SIZE));
+	return reverse(Buffer.from(input).slice(0, BUFFER_SIZE));
 };
 
 export const toAddress = (buffer: Buffer): string => {

--- a/packages/lisk-cryptography/src/encrypt.ts
+++ b/packages/lisk-cryptography/src/encrypt.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 import { bufferToHex, hexToBuffer } from './buffer';
 import { convertPrivateKeyEd2Curve, convertPublicKeyEd2Curve } from './convert';
 import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';

--- a/packages/lisk-cryptography/src/hash.ts
+++ b/packages/lisk-cryptography/src/hash.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 import { hexToBuffer } from './buffer';
 
 const cryptoHashSha256 = (data: Buffer): Buffer => {

--- a/packages/lisk-cryptography/src/nacl/fast.ts
+++ b/packages/lisk-cryptography/src/nacl/fast.ts
@@ -13,7 +13,7 @@
  *
  */
 // tslint:disable-next-line no-implicit-dependencies
-import sodium from 'sodium-native';
+import * as sodium from 'sodium-native';
 import { NaclInterface } from './nacl_types';
 
 export const box: NaclInterface['box'] = (

--- a/packages/lisk-cryptography/src/nacl/slow.ts
+++ b/packages/lisk-cryptography/src/nacl/slow.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import tweetnacl from 'tweetnacl';
+import * as tweetnacl from 'tweetnacl';
 import { NaclInterface } from './nacl_types';
 
 export const box: NaclInterface['box'] = (

--- a/packages/lisk-cryptography/test/_setup.ts
+++ b/packages/lisk-cryptography/test/_setup.ts
@@ -14,7 +14,7 @@
  */
 import { Assertion } from 'chai';
 import 'chai/register-expect';
-import sinon from 'sinon';
+import * as sinon from 'sinon';
 
 process.env.NODE_ENV = 'test';
 

--- a/packages/lisk-cryptography/types/buffer-reverse/index.d.ts
+++ b/packages/lisk-cryptography/types/buffer-reverse/index.d.ts
@@ -1,4 +1,5 @@
-// tslint:disable only-arrow-functions
+/// <reference types="node" />
 declare module 'buffer-reverse' {
-	export default function(buffer: Buffer): Buffer;
+	const reverse: (buffer: Buffer) => Buffer;
+	export = reverse;
 }

--- a/packages/lisk-p2p/src/errors.ts
+++ b/packages/lisk-p2p/src/errors.ts
@@ -13,7 +13,7 @@
  *
  */
 /* tslint:disable: max-classes-per-file */
-import VError from 'verror';
+import * as VError from 'verror';
 
 export class PeerTransportError extends VError {
 	public peerId: string;

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -14,9 +14,9 @@
  */
 
 import { EventEmitter } from 'events';
-import http, { Server } from 'http';
+import * as http from 'http';
 import { attach, SCServer, SCServerSocket } from 'socketcluster-server';
-import url from 'url';
+import * as url from 'url';
 
 import { RequestFailError } from './errors';
 import { Peer } from './peer';
@@ -63,7 +63,7 @@ const BASE_10_RADIX = 10;
 
 export class P2P extends EventEmitter {
 	private readonly _config: P2PConfig;
-	private readonly _httpServer: Server;
+	private readonly _httpServer: http.Server;
 	private _isActive: boolean;
 	private readonly _newPeers: Set<P2PPeerInfo>;
 	private readonly _triedPeers: Set<P2PPeerInfo>;
@@ -116,7 +116,7 @@ export class P2P extends EventEmitter {
 
 		this._peerPool = new PeerPool();
 		this._bindHandlersToPeerPool(this._peerPool);
-		
+
 		this._nodeInfo = config.nodeInfo;
 		this._peerPool.applyNodeInfo(this._nodeInfo);
 	}

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -14,7 +14,7 @@
  */
 
 import { EventEmitter } from 'events';
-import querystring from 'querystring';
+import * as querystring from 'querystring';
 import { RPCResponseError } from './errors';
 
 import {
@@ -27,7 +27,7 @@ import {
 
 import { P2PRequest } from './p2p_request';
 
-import socketClusterClient, { SCClientSocket } from 'socketcluster-client';
+import * as socketClusterClient from 'socketcluster-client';
 import { SCServerSocket } from 'socketcluster-server';
 import {
 	validatePeerInfo,
@@ -35,6 +35,8 @@ import {
 	validateProtocolMessage,
 	validateRPCRequest,
 } from './validation';
+
+type SCClientSocket = socketClusterClient.SCClientSocket;
 
 // Local emitted events.
 export const EVENT_UPDATED_PEER_INFO = 'updatedPeerInfo';

--- a/packages/lisk-p2p/test/_setup.ts
+++ b/packages/lisk-p2p/test/_setup.ts
@@ -12,11 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import 'chai/register-expect';
-import sinonChai from 'sinon-chai';
-import sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
 
 process.env.NODE_ENV = 'test';
 

--- a/packages/lisk-passphrase/package.json
+++ b/packages/lisk-passphrase/package.json
@@ -22,6 +22,8 @@
 	},
 	"main": "dist-node/index.js",
 	"scripts": {
+		"prestart": "./scripts/prestart.sh",
+		"start": "./scripts/start.sh",
 		"transpile": "tsc",
 		"transpile:browsertest": "tsc -p tsconfig.browsertest.json",
 		"browserify": "browserify ./dist-node/index.js -o ./dist-browser/index.js -s liskPassphrase",

--- a/packages/lisk-passphrase/src/index.ts
+++ b/packages/lisk-passphrase/src/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import Mnemonic from 'bip39';
+import * as Mnemonic from 'bip39';
 import * as validation from './validation';
 
 export { Mnemonic, validation };

--- a/packages/lisk-passphrase/src/validation.ts
+++ b/packages/lisk-passphrase/src/validation.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import Mnemonic from 'bip39';
+import * as Mnemonic from 'bip39';
 
 interface PassphraseRegularExpression {
 	readonly uppercaseRegExp: RegExp;

--- a/packages/lisk-passphrase/test/validation.ts
+++ b/packages/lisk-passphrase/test/validation.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import Mnemonic from 'bip39';
+import * as Mnemonic from 'bip39';
 import { expect } from 'chai';
 import {
 	countPassphraseWhitespaces,

--- a/packages/lisk-transaction-pool/test/_setup.ts
+++ b/packages/lisk-transaction-pool/test/_setup.ts
@@ -12,9 +12,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import chai from 'chai';
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
 
 process.env.NODE_ENV = 'test';
 

--- a/packages/lisk-transaction-pool/test/integration/transaction_movement.ts
+++ b/packages/lisk-transaction-pool/test/integration/transaction_movement.ts
@@ -9,7 +9,7 @@ import {
 	wrapExpectationInNextTick,
 } from './helpers/common';
 import { returnTrueUntilLimit } from '../../src/queue_checkers';
-import transactionObjects from '../../fixtures/transactions.json';
+import * as transactionObjects from '../../fixtures/transactions.json';
 import { wrapTransaction } from '../utils/add_transaction_functions';
 import { SinonFakeTimers } from 'sinon';
 import { expect } from 'chai';

--- a/packages/lisk-transaction-pool/test/integration/transaction_pool_events.ts
+++ b/packages/lisk-transaction-pool/test/integration/transaction_pool_events.ts
@@ -7,7 +7,7 @@ import {
 	fakeCheckFunctionGenerator,
 	fakeCheckerFunctionGenerator,
 } from './helpers/common';
-import transactionObjects from '../../fixtures/transactions.json';
+import * as transactionObjects from '../../fixtures/transactions.json';
 import { wrapTransaction } from '../utils/add_transaction_functions';
 import { expect } from 'chai';
 

--- a/packages/lisk-transaction-pool/test/performance/queue.ts
+++ b/packages/lisk-transaction-pool/test/performance/queue.ts
@@ -1,62 +1,65 @@
 import { Queue } from '../../src/queue';
-import transactionObjects from '../../fixtures/transactions.json';
+import * as transactionObjects from '../../fixtures/transactions.json';
 import { wrapTransaction } from '../utils/add_transaction_functions';
 import { expect } from 'chai';
-import { returnTrueUntilLimit, checkTransactionForId } from '../../src/queue_checkers';
+import {
+	returnTrueUntilLimit,
+	checkTransactionForId,
+} from '../../src/queue_checkers';
 
 describe('queue', () => {
-    const transactions = transactionObjects.map(wrapTransaction);
-    let queue: Queue;
+	const transactions = transactionObjects.map(wrapTransaction);
+	let queue: Queue;
 
-    beforeEach(() => {
-        queue = new Queue();
-    });
+	beforeEach(() => {
+		queue = new Queue();
+	});
 
-    describe('#enqueueOne', () => {
-        it('should enqueue 1000 transactions in under 100 milliseconds', async () => {
-            const startTime = new Date().getTime();
-            transactions.forEach(transaction => queue.enqueueOne(transaction));
-            const endTime = new Date().getTime();
-            expect(endTime - startTime).to.be.lessThan(100);
-        });
-    });
+	describe('#enqueueOne', () => {
+		it('should enqueue 1000 transactions in under 100 milliseconds', async () => {
+			const startTime = new Date().getTime();
+			transactions.forEach(transaction => queue.enqueueOne(transaction));
+			const endTime = new Date().getTime();
+			expect(endTime - startTime).to.be.lessThan(100);
+		});
+	});
 
-    describe('#dequeueUntil', () => {
-        beforeEach(async () => {
-            transactions.forEach(transaction => queue.enqueueOne(transaction));
-        });
+	describe('#dequeueUntil', () => {
+		beforeEach(async () => {
+			transactions.forEach(transaction => queue.enqueueOne(transaction));
+		});
 
-        it('should dequeue 1000 transactions in under 100 milliseconds', async () => {
-            const startTime = new Date().getTime();
-            queue.dequeueUntil(returnTrueUntilLimit(1000));
-            const endTime = new Date().getTime();
-            expect(endTime - startTime ).to.be.lessThan(100);
-        });
-    });
+		it('should dequeue 1000 transactions in under 100 milliseconds', async () => {
+			const startTime = new Date().getTime();
+			queue.dequeueUntil(returnTrueUntilLimit(1000));
+			const endTime = new Date().getTime();
+			expect(endTime - startTime).to.be.lessThan(100);
+		});
+	});
 
-    describe('#removeFor', () => {
-        beforeEach(async () => {
-            transactions.forEach(transaction => queue.enqueueOne(transaction));
-        });
+	describe('#removeFor', () => {
+		beforeEach(async () => {
+			transactions.forEach(transaction => queue.enqueueOne(transaction));
+		});
 
-        it('should remove 1000 transactions in under 100 milliseconds', async () => {
-            const startTime = new Date().getTime();
-            queue.removeFor(checkTransactionForId(transactions));
-            const endTime = new Date().getTime();
-            expect(endTime - startTime).to.be.lessThan(100);
-        });
-    });
+		it('should remove 1000 transactions in under 100 milliseconds', async () => {
+			const startTime = new Date().getTime();
+			queue.removeFor(checkTransactionForId(transactions));
+			const endTime = new Date().getTime();
+			expect(endTime - startTime).to.be.lessThan(100);
+		});
+	});
 
-    describe('#peekUntil', () => {
-        beforeEach(async () => {
-            transactions.forEach(transaction => queue.enqueueOne(transaction));
-        });
+	describe('#peekUntil', () => {
+		beforeEach(async () => {
+			transactions.forEach(transaction => queue.enqueueOne(transaction));
+		});
 
-        it('should peek 100 transactions in under 100 milliseconds', async () => {
-            const startTime = new Date().getTime();
-            queue.peekUntil(returnTrueUntilLimit(100));
-            const endTime = new Date().getTime();
-            expect(endTime - startTime).to.be.lessThan(100);
-        });
-    });
+		it('should peek 100 transactions in under 100 milliseconds', async () => {
+			const startTime = new Date().getTime();
+			queue.peekUntil(returnTrueUntilLimit(100));
+			const endTime = new Date().getTime();
+			expect(endTime - startTime).to.be.lessThan(100);
+		});
+	});
 });

--- a/packages/lisk-transaction-pool/test/unit/check_transactions.ts
+++ b/packages/lisk-transaction-pool/test/unit/check_transactions.ts
@@ -19,7 +19,7 @@ import {
 	checkTransactionsWithPassAndFail,
 } from '../../src/check_transactions';
 import { expect } from 'chai';
-import transactionObjects from '../../fixtures/transactions.json';
+import * as transactionObjects from '../../fixtures/transactions.json';
 import { wrapTransaction } from '../utils/add_transaction_functions';
 
 describe('#checkTransactions', () => {

--- a/packages/lisk-transaction-pool/test/unit/queue.ts
+++ b/packages/lisk-transaction-pool/test/unit/queue.ts
@@ -16,7 +16,7 @@
 import { Queue } from '../../src/queue';
 import { Transaction } from '../../src/transaction_pool';
 import { expect } from 'chai';
-import transactionObjects from '../../fixtures/transactions.json';
+import * as transactionObjects from '../../fixtures/transactions.json';
 import { wrapTransaction } from '../utils/add_transaction_functions';
 
 const transactions = transactionObjects.map(wrapTransaction);

--- a/packages/lisk-transaction-pool/test/unit/queue_checkers.ts
+++ b/packages/lisk-transaction-pool/test/unit/queue_checkers.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Transaction } from '../../src/transaction_pool';
 import { wrapTransaction } from '../utils/add_transaction_functions';
 import * as queueCheckers from '../../src/queue_checkers';
-import transactionObjects from '../../fixtures/transactions.json';
+import * as transactionObjects from '../../fixtures/transactions.json';
 import { SinonStub } from 'sinon';
 
 describe('queueCheckers', () => {

--- a/packages/lisk-transaction-pool/test/unit/transaction_pool.ts
+++ b/packages/lisk-transaction-pool/test/unit/transaction_pool.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import transactionObjects from '../../fixtures/transactions.json';
+import * as transactionObjects from '../../fixtures/transactions.json';
 import { Job } from '../../src/job';
 import {
 	Transaction,

--- a/packages/lisk-transactions/fixtures/index.ts
+++ b/packages/lisk-transactions/fixtures/index.ts
@@ -12,22 +12,22 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import validAccount from './valid_account.json';
-import validDappTransactions from './valid_dapp_transactions.json';
-import validDelegateAccount from './valid_delegate_account.json';
-import validDelegateTransaction from './valid_delegate_transaction.json';
-import validInTransferTransactions from './valid_in_transfer_transaction.json';
-import validMultisignatureAccount from './valid_multisignature_account.json';
-import validMultisignatureRegistrationTransaction from  './valid_multisignature_transaction.json';
-import validOutTransferTransactions from './valid_out_transfer_transactions.json';
-import validRegisterSecondSignatureTransaction from './valid_register_second_signature_transaction.json';
-import validSecondSignatureAccount from './valid_second_signature_account.json';
-import validTransaction from './valid_transaction.json';
-import validMultisignatureTransaction from './valid_transaction_from_multisignature_account.json';
-import validSecondSignatureTransaction from './valid_transaction_from_second_signature_account.json';
-import validTransferAccount from './valid_transfer_account.json';
-import validTransferTransactions from './valid_transfer_transactions.json';
-import validVoteTransactions from './valid_vote_transaction.json';
+import * as validAccount from './valid_account.json';
+import * as validDappTransactions from './valid_dapp_transactions.json';
+import * as validDelegateAccount from './valid_delegate_account.json';
+import * as validDelegateTransaction from './valid_delegate_transaction.json';
+import * as validInTransferTransactions from './valid_in_transfer_transaction.json';
+import * as validMultisignatureAccount from './valid_multisignature_account.json';
+import * as validMultisignatureRegistrationTransaction from './valid_multisignature_transaction.json';
+import * as validOutTransferTransactions from './valid_out_transfer_transactions.json';
+import * as validRegisterSecondSignatureTransaction from './valid_register_second_signature_transaction.json';
+import * as validSecondSignatureAccount from './valid_second_signature_account.json';
+import * as validTransaction from './valid_transaction.json';
+import * as validMultisignatureTransaction from './valid_transaction_from_multisignature_account.json';
+import * as validSecondSignatureTransaction from './valid_transaction_from_second_signature_account.json';
+import * as validTransferAccount from './valid_transfer_account.json';
+import * as validTransferTransactions from './valid_transfer_transactions.json';
+import * as validVoteTransactions from './valid_vote_transaction.json';
 
 export {
 	validAccount,

--- a/packages/lisk-transactions/src/transactions/0_transfer.ts
+++ b/packages/lisk-transactions/src/transactions/0_transfer.ts
@@ -13,7 +13,7 @@
  *
  */
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { BYTESIZES, MAX_TRANSACTION_AMOUNT, TRANSFER_FEE } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import {
@@ -137,7 +137,7 @@ export class TransferTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid asset types', tx.id, errors);
 		}
 		this.asset = tx.asset as TransferAsset;
-		this._fee = new BigNum(TRANSFER_FEE); 
+		this._fee = new BigNum(TRANSFER_FEE);
 	}
 
 	public static create(input: TransferInput): object {

--- a/packages/lisk-transactions/src/transactions/1_register_second_passphrase.ts
+++ b/packages/lisk-transactions/src/transactions/1_register_second_passphrase.ts
@@ -13,7 +13,7 @@
  *
  */
 import { getKeys, hexToBuffer } from '@liskhq/lisk-cryptography';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { SIGNATURE_FEE } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import {

--- a/packages/lisk-transactions/src/transactions/2_register_delegate.ts
+++ b/packages/lisk-transactions/src/transactions/2_register_delegate.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { DELEGATE_FEE, USERNAME_MAX_LENGTH } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import {
@@ -89,9 +89,10 @@ export interface CreateDelegateRegistrationInput {
 	readonly username: string;
 }
 
-export type RegisterDelegateInput = CreateBaseTransactionInput &  CreateDelegateRegistrationInput;
+export type RegisterDelegateInput = CreateBaseTransactionInput &
+	CreateDelegateRegistrationInput;
 
-const validateInput = ({ username }:  RegisterDelegateInput): void => {
+const validateInput = ({ username }: RegisterDelegateInput): void => {
 	if (!username || typeof username !== 'string') {
 		throw new Error('Please provide a username. Expected string.');
 	}
@@ -123,14 +124,14 @@ export class DelegateTransaction extends BaseTransaction {
 		this._fee = new BigNum(DELEGATE_FEE);
 	}
 
-	public static create(input:  RegisterDelegateInput): object {
+	public static create(input: RegisterDelegateInput): object {
 		validateInput(input);
 		const { username, passphrase, secondPassphrase } = input;
 
 		if (!username || typeof username !== 'string') {
 			throw new Error('Please provide a username. Expected string.');
 		}
-	
+
 		if (username.length > USERNAME_MAX_LENGTH) {
 			throw new Error(
 				`Username length does not match requirements. Expected to be no more than ${USERNAME_MAX_LENGTH} characters.`,
@@ -202,7 +203,7 @@ export class DelegateTransaction extends BaseTransaction {
 		const errors = transactions
 			.filter(
 				tx =>
-				tx.type === this.type && tx.senderPublicKey === this.senderPublicKey,
+					tx.type === this.type && tx.senderPublicKey === this.senderPublicKey,
 			)
 			.map(
 				tx =>
@@ -234,8 +235,7 @@ export class DelegateTransaction extends BaseTransaction {
 		}
 
 		const dependentAccounts = accounts.filter(
-			acct =>
-				acct.username === this.asset.delegate.username,
+			acct => acct.username === this.asset.delegate.username,
 		);
 
 		return {
@@ -286,10 +286,13 @@ export class DelegateTransaction extends BaseTransaction {
 
 		if (this.recipientPublicKey) {
 			errors.push(
-				new TransactionError('Invalid recipientPublicKey', this.id, '.recipientPublicKey'),
+				new TransactionError(
+					'Invalid recipientPublicKey',
+					this.id,
+					'.recipientPublicKey',
+				),
 			);
 		}
-
 
 		return {
 			id: this.id,
@@ -307,9 +310,11 @@ export class DelegateTransaction extends BaseTransaction {
 	}: RequiredDelegateState): TransactionResponse {
 		const { errors: baseErrors } = super.verify({ sender });
 		const errors = [...baseErrors];
-		const usernameUnique = dependentState ? dependentState[ENTITY_ACCOUNT].every(
-			({ username }) => username !== this.asset.delegate.username,
-		) : true;
+		const usernameUnique = dependentState
+			? dependentState[ENTITY_ACCOUNT].every(
+					({ username }) => username !== this.asset.delegate.username,
+			  )
+			: true;
 
 		if (!usernameUnique) {
 			errors.push(
@@ -338,15 +343,20 @@ export class DelegateTransaction extends BaseTransaction {
 		};
 	}
 
-	public apply({ sender, dependentState }: RequiredDelegateState): TransactionResponse {
+	public apply({
+		sender,
+		dependentState,
+	}: RequiredDelegateState): TransactionResponse {
 		const { errors: baseErrors, state } = super.apply({ sender });
 		if (!state) {
 			throw new Error('State is required for applying transaction.');
 		}
 		const errors = [...baseErrors];
-		const usernameUnique = dependentState ? dependentState[ENTITY_ACCOUNT].every(
-			({ username }) => username !== this.asset.delegate.username,
-		) : true;
+		const usernameUnique = dependentState
+			? dependentState[ENTITY_ACCOUNT].every(
+					({ username }) => username !== this.asset.delegate.username,
+			  )
+			: true;
 		if (!usernameUnique) {
 			errors.push(
 				new TransactionError(

--- a/packages/lisk-transactions/src/transactions/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/3_vote_transaction.ts
@@ -13,7 +13,7 @@
  *
  */
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { VOTE_FEE } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import { Account, Status, TransactionJSON } from '../transaction_types';

--- a/packages/lisk-transactions/src/transactions/4_register_multisignature.ts
+++ b/packages/lisk-transactions/src/transactions/4_register_multisignature.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import {
 	MULTISIGNATURE_FEE,
 	MULTISIGNATURE_MAX_KEYSGROUP,
@@ -238,7 +238,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 				min: this.asset.multisignature.min,
 				lifetime: this.asset.multisignature.lifetime,
 				keysgroup: [...this.asset.multisignature.keysgroup],
-			}
+			},
 		};
 	}
 
@@ -439,7 +439,12 @@ export class MultisignatureTransaction extends BaseTransaction {
 		}
 		const errors = [...baseErrors];
 
-		const { multisignatures, multimin, multilifetime, ...strippedSender } = state.sender;
+		const {
+			multisignatures,
+			multimin,
+			multilifetime,
+			...strippedSender
+		} = state.sender;
 
 		return {
 			id: this.id,

--- a/packages/lisk-transactions/src/transactions/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/5_dapp_transaction.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { DAPP_FEE } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import { Account, Status, TransactionJSON } from '../transaction_types';

--- a/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { IN_TRANSFER_FEE } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import { Account, Status, TransactionJSON } from '../transaction_types';

--- a/packages/lisk-transactions/src/transactions/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/7_out_transfer_transaction.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { OUT_TRANSFER_FEE } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import { Account, Status, TransactionJSON } from '../transaction_types';

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -23,7 +23,7 @@ import {
 	hexToBuffer,
 	signData,
 } from '@liskhq/lisk-cryptography';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import {
 	BYTESIZES,
 	MAX_TRANSACTION_AMOUNT,
@@ -156,8 +156,8 @@ export abstract class BaseTransaction {
 	}
 
 	public get fee(): BigNum {
-		if(!this._fee) {
-			throw new Error('fee is required to be set before use')
+		if (!this._fee) {
+			throw new Error('fee is required to be set before use');
 		}
 
 		return this._fee;
@@ -520,10 +520,7 @@ export abstract class BaseTransaction {
 		sender,
 	}: RequiredState): TransactionResponse {
 		const transactionBytes = this.signSignature
-			? Buffer.concat([
-					this.getBasicBytes(),
-					hexToBuffer(this.signature),
-			  ])
+			? Buffer.concat([this.getBasicBytes(), hexToBuffer(this.signature)])
 			: this.getBasicBytes();
 
 		if (!sender.multimin) {

--- a/packages/lisk-transactions/src/utils/format.ts
+++ b/packages/lisk-transactions/src/utils/format.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { FIXED_POINT } from '../constants';
 import { isGreaterThanMaxTransactionAmount } from './validation';
 

--- a/packages/lisk-transactions/src/utils/get_transaction_bytes.ts
+++ b/packages/lisk-transactions/src/utils/get_transaction_bytes.ts
@@ -13,7 +13,7 @@
  *
  */
 import * as cryptography from '@liskhq/lisk-cryptography';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { BYTESIZES, MAX_TRANSACTION_AMOUNT } from '../constants';
 import {
 	DappAsset,

--- a/packages/lisk-transactions/src/utils/validation/validation.ts
+++ b/packages/lisk-transactions/src/utils/validation/validation.ts
@@ -15,7 +15,7 @@
 // tslint:disable-next-line no-reference
 /// <reference path="../../../types/browserify-bignum/index.d.ts" />
 import * as cryptography from '@liskhq/lisk-cryptography';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import {
 	MAX_ADDRESS_NUMBER,
 	MAX_PUBLIC_KEY_LENGTH,

--- a/packages/lisk-transactions/src/utils/validation/validator.ts
+++ b/packages/lisk-transactions/src/utils/validation/validator.ts
@@ -12,9 +12,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import Ajv from 'ajv';
-import addKeywords from 'ajv-merge-patch';
-import BigNum from 'browserify-bignum';
+import * as Ajv from 'ajv';
+// tslint:disable-next-line no-require-imports
+import addKeywords = require('ajv-merge-patch');
+import * as BigNum from 'browserify-bignum';
 import * as schemas from './schema';
 import {
 	isGreaterThanMaxTransactionId,

--- a/packages/lisk-transactions/src/utils/verify_balance.ts
+++ b/packages/lisk-transactions/src/utils/verify_balance.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { TransactionError } from '../errors';
 import { Account, IsVerifiedResponseWithError } from '../transaction_types';
 import { convertBeddowsToLSK } from './';

--- a/packages/lisk-transactions/test/_setup.ts
+++ b/packages/lisk-transactions/test/_setup.ts
@@ -12,19 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import sinon from 'sinon';
-import chai, { Assertion } from 'chai';
+import * as sinon from 'sinon';
+import * as chai from 'chai';
 import 'chai/register-expect';
-import sinonChai from 'sinon-chai';
+import * as sinonChai from 'sinon-chai';
 
 process.env.NODE_ENV = 'test';
 
-Assertion.addProperty('hexString', function handleAssert(
+chai.Assertion.addProperty('hexString', function handleAssert(
 	this: Chai.ChaiStatic,
 ) {
 	const actual = this._obj;
 
-	new Assertion(actual).to.be.a('string');
+	new chai.Assertion(actual).to.be.a('string');
 
 	const expected = Buffer.from(actual, 'hex').toString('hex');
 	this.assert(
@@ -34,10 +34,12 @@ Assertion.addProperty('hexString', function handleAssert(
 	);
 });
 
-Assertion.addProperty('integer', function handleAssert(this: Chai.ChaiStatic) {
+chai.Assertion.addProperty('integer', function handleAssert(
+	this: Chai.ChaiStatic,
+) {
 	const actual = this._obj;
 
-	new Assertion(actual).to.be.a('number');
+	new chai.Assertion(actual).to.be.a('number');
 
 	const expected = parseInt(actual, 10);
 	this.assert(

--- a/packages/lisk-transactions/test/transactions/0_transfer.ts
+++ b/packages/lisk-transactions/test/transactions/0_transfer.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { expect } from 'chai';
 import { SinonStub } from 'sinon';
 import { MAX_TRANSACTION_AMOUNT, TRANSFER_FEE } from '../../src/constants';

--- a/packages/lisk-transactions/test/transactions/base.ts
+++ b/packages/lisk-transactions/test/transactions/base.ts
@@ -23,7 +23,7 @@ import {
 	TransactionMultiError,
 	TransactionPendingError,
 } from '../../src/errors';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { addTransactionFields, TestTransaction } from '../helpers';
 import {
 	validAccount as defaultSenderAccount,

--- a/packages/lisk-transactions/test/utils/get_transaction_bytes.ts
+++ b/packages/lisk-transactions/test/utils/get_transaction_bytes.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import {
 	getTransactionBytes,
 	getAssetDataForTransferTransaction,

--- a/packages/lisk-transactions/test/utils/sign_and_verify.ts
+++ b/packages/lisk-transactions/test/utils/sign_and_verify.ts
@@ -25,7 +25,7 @@ import {
 import { TransactionError, TransactionPendingError } from '../../src/errors';
 // The list of valid transactions was created with lisk-js v0.5.1
 // using the below mentioned passphrases.
-import fixtureTransactions from '../../fixtures/transactions.json';
+import * as fixtureTransactions from '../../fixtures/transactions.json';
 import { Account, TransactionJSON } from '../../src/transaction_types';
 import * as getTransactionHashModule from '../../src/utils/get_transaction_hash';
 import {

--- a/packages/lisk-transactions/test/utils/validation/validate_transaction.ts
+++ b/packages/lisk-transactions/test/utils/validation/validate_transaction.ts
@@ -13,8 +13,8 @@
  *
  */
 import { expect } from 'chai';
-import fixtures from '../../../fixtures/transactions.json';
-import invalidFixtures from '../../../fixtures/invalid_transactions.json';
+import * as fixtures from '../../../fixtures/transactions.json';
+import * as invalidFixtures from '../../../fixtures/invalid_transactions.json';
 import { validateTransaction } from '../../../src/utils/validation/validate_transaction';
 import { TransactionJSON } from '../../../src/transaction_types';
 import { ErrorObject } from 'ajv';

--- a/packages/lisk-transactions/test/utils/validation/validation.ts
+++ b/packages/lisk-transactions/test/utils/validation/validation.ts
@@ -14,7 +14,7 @@
  */
 import * as cryptography from '@liskhq/lisk-cryptography';
 import { expect } from 'chai';
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import {
 	checkPublicKeysForDuplicates,
 	validatePublicKey,

--- a/packages/lisk-transactions/test/utils/verify_balance.ts
+++ b/packages/lisk-transactions/test/utils/verify_balance.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BigNum from 'browserify-bignum';
+import * as BigNum from 'browserify-bignum';
 import { expect } from 'chai';
 import { verifyBalance } from '../../src/utils';
 import { TransactionError } from '../../src/errors';

--- a/packages/lisk-transactions/types/ajv-merge-patch/index.d.ts
+++ b/packages/lisk-transactions/types/ajv-merge-patch/index.d.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:only-arrow-functions */
 declare module 'ajv-merge-patch' {
-	export default function addKeywords(ajv: object): void;
+	const addKeywords: (ajv: object) => void;
+	export = addKeywords;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"target": "es2017",
 		"module": "commonjs",


### PR DESCRIPTION
### What was the problem?
If esModuleInterop is true, there was no option to disable it on the client side.

### How did I fix it?
Turn off esModuleInterop on root level tsconfig, and fix the build and test error

### How to test it?
`npm t`

### Review checklist

* The PR resolves #933 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
