### PR TITLE
Initialization start(), stop() and peer management - Addresses #894 and #895 

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -12,59 +12,197 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-/* tslint:disable:no-unused-expression */
+
+import { EventEmitter } from 'events';
+import http, { Server } from 'http';
+import os from 'os';
+import querystring from 'querystring';
+import socketClusterServer from 'socketcluster-server';
+
 import {
 	NetworkStatus,
-	P2PConfig,
 	P2PMessagePacket,
 	P2PNodeStatus,
-	P2PPenality,
+	P2PPenalty,
 	P2PRequestPacket,
 	P2PResponsePacket,
+	P2PConfig,
+	PeerInfo,
+	RPCResponsePeerList,
+	RPCResponsePeerInfo,
+	NodeInfo,
 } from './p2p_types';
 
 import { PeerPool } from './peer_pool';
 
-export class P2P {
-	private readonly peerPool: PeerPool;
+export const EVENT_NEW_INBOUND_PEER = 'newInboundPeer';
+export const EVENT_FAILED_TO_ADD_INBOUND_PEER = 'failedToAddInboundPeer';
+export const EVENT_NEW_PEER = 'newPeer';
+
+export interface IPeerReturnType {
+	readonly options: IPeerOptions;
+	readonly peers: ReadonlyArray<Peer>;
+}
+export interface IPeerOptions {
+	readonly [key: string]: string | number;
+}
+
+const BASE_10_RADIX = 10;
+
+export class P2P extends EventEmitter {
+	private readonly _config: P2PConfig;
+	private readonly _peerPool: PeerPool;
+	private readonly _httpServer: Server;
+	private readonly _scServer: any;
+	private readonly _newPeers: Set<string>;
+	private readonly _triedPeers: Set<string>;
+	private readonly _nodeInfo: NodeInfo;
 
 	public constructor(config: P2PConfig) {
-		this.peerPool = new PeerPool({
-			blacklistedPeers: config.blacklistedPeers,
-			connectTimeout: config.connectTimeout,
-			ipAddress: config.ipAddress,
-			seedPeers: config.seedPeers,
-			wsEngine: config.wsEngine,
+		super();
+		this._config = config;
+		this._nodeInfo = {
 			wsPort: config.wsPort,
-		});
+			os: os.platform(),
+			version: config.version,
+		};
+		this._newPeers = new Set();
+		this._triedPeers = new Set();
+
+		this._peerPool = new PeerPool();
+		this._httpServer = http.createServer();
+		this._scServer = socketClusterServer.attach(this._httpServer);
 	}
 
-	public applyPenalty = (penalty: P2PPenality): void => {
+	public applyPenalty = (penalty: P2PPenalty): void => {
 		penalty;
 	};
 	// TODO
 	public getNetworkStatus = (): NetworkStatus => true;
 	// TODO
+
 	public getNodeStatus = (): P2PNodeStatus => true;
-	// TODO
-	public request = async (
-		packet: P2PRequestPacket,
-	): Promise<P2PResponsePacket> => {
-		const response = packet;
+	// TODO: Implement
 
-		return Promise.resolve(response);
-	};
+	public async request<T>(
+		packet: P2PRequestPacket<T>,
+	): Promise<P2PResponsePacket> {
+		return Promise.resolve({ data: packet });
+	}
 
-	public send = (message: P2PMessagePacket): void => {
+	public send<T>(message: P2PMessagePacket<T>): void {
 		message;
 		// TODO
-	};
+	}
 	public setNodeStatus = (nodeStatus: P2PNodeStatus): void => {
 		nodeStatus;
 		// TODO
 	};
-	// TODO
-	public start = async (): Promise<void> => this.peerPool.start();
-	// TODO
-	public stop = async (): Promise<void> => this.peerPool.stop();
+
+	private async _startPeerServer(): Promise<void> {
+		this._scServer.on(
+			'connection',
+			(socket: any): void => {
+				const queryObject = querystring.parse(socket.request.url);
+				if (
+					typeof queryObject.wsPort !== 'string' ||
+					typeof queryObject.os !== 'string' ||
+					typeof queryObject.version !== 'string'
+				) {
+					super.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER);
+				} else {
+					const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
+					const peerId = P2P.generatePeerIdFromPeerInfo({
+						ipAddress: socket.remoteAddress,
+						wsPort,
+					});
+					const existingPeer = this._peerPool.getPeer(peerId);
+					if (existingPeer === undefined) {
+						const peer = new Peer({
+							height: 0,
+							id: peerId,
+							inboundSocket: socket,
+							ipAddress: socket.remoteAddress,
+							os: queryObject.os,
+							version: queryObject.version,
+							wsPort,
+							nodeInfo: this._nodeInfo,
+						});
+						this._peerPool.addPeer(peer);
+						super.emit(EVENT_NEW_INBOUND_PEER, peer);
+						super.emit(EVENT_NEW_PEER, peer);
+					} else {
+						existingPeer.inboundSocket = socket;
+					}
+					this._triedPeers.add(peerId);
+				}
+			},
+		);
+		this._httpServer.listen(this._config.wsPort);
+
+		return new Promise<void>(resolve => {
+			this._scServer.once('ready', () => {
+				resolve();
+			});
+		});
+	}
+
+	public async _loadListOfPeerListsFromSeeds(
+		seedList: ReadonlyArray<PeerInfo>,
+	): Promise<ReadonlyArray<ReadonlyArray<Peer>>> {
+		return Promise.all(
+			seedList.map(async (seedPeer: PeerInfo) => {
+				const seedPeerId = P2P.generatePeerIdFromPeerInfo(seedPeer);
+				const peer = new Peer({
+					id: seedPeerId,
+					ipAddress: seedPeer.ipAddress,
+					wsPort: seedPeer.wsPort,
+					nodeInfo: this._nodeInfo,
+				});
+				/**
+				 * TODO LATER: For the LIP phase, we shouldn't add the seed peers to our
+				 * _peerPool and we should disconnect from them as soon as we've loaded their peer lists.
+				 */
+				this._newPeers.add(seedPeerId);
+				this._peerPool.addPeer(peer);
+				// TODO LATER: For the LIP phase, the 'list' request will need to be renamed.
+				const seedNodePeerListResponse = await peer.request<void>({
+					procedure: 'list',
+				});
+				const peerListResponse = seedNodePeerListResponse.data as RPCResponsePeerList;
+				// TODO ASAP: Validate the response before returning. Check that seedNodePeerListResponse.data.peers exists.
+
+				return peerListResponse.peers.map((peerObject: RPCResponsePeerInfo) => {
+					const peerOfPeerId = P2P.generatePeerIdFromPeerInfo({
+						ipAddress: peerObject.ip,
+						wsPort: peerObject.wsPort,
+					});
+
+					return new Peer({
+						id: peerOfPeerId,
+						ipAddress: peerObject.ip,
+						wsPort: peerObject.wsPort, // TODO ASAP: Add more properties
+						nodeInfo: this._nodeInfo,
+					});
+				});
+			}),
+		);
+	}
+
+	public start = async (): Promise<void> => {
+		await this._startPeerServer();
+		await this._loadListOfPeerListsFromSeeds(this._config.seedPeers);
+	};
+
+	public stop = async (): Promise<void> => {
+		this._peerPool.disconnectAllPeers();
+		// In the current implementation, we don't need to shut down any child processes.
+		// This method resolves immediately.
+
+		return Promise.resolve();
+	};
+
+	public static generatePeerIdFromPeerInfo(peerInfo: PeerInfo): string {
+		return `${peerInfo.ipAddress}:${peerInfo.wsPort}`;
+	}
 }

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -22,7 +22,7 @@ import socketClusterServer from 'socketcluster-server';
 import { Peer } from './peer';
 
 import {
-	NetworkStatus,
+	// TODO ASAP: NetworkStatus,
 	P2PMessagePacket,
 	P2PPenalty,
 	P2PRequestPacket,
@@ -48,7 +48,7 @@ export class P2P extends EventEmitter {
 	private readonly _httpServer: Server;
 	private readonly _scServer: any;
 	private readonly _newPeers: Set<string>;
-	// TODO: private readonly _triedPeers: Set<string>;
+	// TODO ASAP: private readonly _triedPeers: Set<string>;
 	private _nodeStatus: P2PNodeStatus;
 
 	public constructor(config: P2PConfig) {
@@ -60,19 +60,18 @@ export class P2P extends EventEmitter {
 			version: config.version,
 		};
 		this._newPeers = new Set();
-		// TODO: this._triedPeers = new Set();
+		// TODO ASAP: this._triedPeers = new Set();
 
 		this._peerPool = new PeerPool();
 		this._httpServer = http.createServer();
 		this._scServer = socketClusterServer.attach(this._httpServer);
 	}
 
-	public applyPenalty = (penalty: P2PPenalty): void => {
+	public applyPenalty(penalty: P2PPenalty): void {
 		penalty;
 	};
-	// TODO
-	public getNetworkStatus = (): NetworkStatus => true;
-	// TODO
+
+	// TODO ASAP: public getNetworkStatus(): NetworkStatus {};
 
 	public async request<T>(
 		packet: P2PRequestPacket<T>,
@@ -82,7 +81,7 @@ export class P2P extends EventEmitter {
 
 	public send<T>(message: P2PMessagePacket<T>): void {
 		message;
-		// TODO
+		// TODO ASAP
 	}
 
 	public get nodeStatus(): P2PNodeStatus {
@@ -142,7 +141,7 @@ export class P2P extends EventEmitter {
 	}
 
 	private async _stopPeerServer(): Promise<void> {
-		// TODO: Test this and check for potential failure scenarios.
+		// TODO ASAP: Test this and check for potential failure scenarios.
 		return new Promise<void>(resolve => {
 			this._scServer.close(() => {
 				resolve();
@@ -192,12 +191,12 @@ export class P2P extends EventEmitter {
 		);
 	}
 
-	public start = async (): Promise<void> => {
+	public async start(): Promise<void> {
 		await this._startPeerServer();
 		await this._loadListOfPeerListsFromSeeds(this._config.seedPeers);
 	};
 
-	public stop = async (): Promise<void> => {
+	public async stop(): Promise<void> {
 		this._peerPool.disconnectAllPeers();
 		await this._stopPeerServer();
 	};

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -85,12 +85,12 @@ export class P2P extends EventEmitter {
 		// TODO
 	}
 
-	public getNodeStatus(): P2PNodeStatus {
+	public get nodeStatus(): P2PNodeStatus {
 		return this._nodeStatus;
 	}
 
-	public setNodeStatus(nodeStatus: P2PNodeStatus): void {
-		this._nodeStatus = nodeStatus;
+	public set nodeStatus(value: P2PNodeStatus) {
+		this._nodeStatus = value;
 	}
 
 	private async _startPeerServer(): Promise<void> {
@@ -136,6 +136,15 @@ export class P2P extends EventEmitter {
 
 		return new Promise<void>(resolve => {
 			this._scServer.once('ready', () => {
+				resolve();
+			});
+		});
+	}
+
+	private async _stopPeerServer(): Promise<void> {
+		// TODO: Test this and check for potential failure scenarios.
+		return new Promise<void>(resolve => {
+			this._scServer.close(() => {
 				resolve();
 			});
 		});
@@ -190,10 +199,7 @@ export class P2P extends EventEmitter {
 
 	public stop = async (): Promise<void> => {
 		this._peerPool.disconnectAllPeers();
-		// In the current implementation, we don't need to shut down any child processes.
-		// This method resolves immediately.
-
-		return Promise.resolve();
+		await this._stopPeerServer();
 	};
 
 	public static generatePeerIdFromPeerInfo(peerInfo: PeerInfo): string {

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -150,7 +150,7 @@ export class P2P extends EventEmitter {
 		});
 	}
 
-	public async _loadListOfPeerListsFromSeeds(
+	private async _loadListOfPeerListsFromSeeds(
 		seedList: ReadonlyArray<PeerConfig>,
 	): Promise<ReadonlyArray<ReadonlyArray<Peer>>> {
 		return Promise.all(

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -88,8 +88,13 @@ export class P2P extends EventEmitter {
 		return this._nodeStatus;
 	}
 
-	public set nodeStatus(value: P2PNodeStatus) {
+	/**
+	 * This is not a declared as a setter because this method will need
+	 * invoke an async RPC on Peers to give them our new node status.
+	 */
+	public applyNodeStatus(value: P2PNodeStatus): void {
 		this._nodeStatus = value;
+		// TODO ASAP: Pass to PeerPool -> connected Peer objects
 	}
 
 	private async _startPeerServer(): Promise<void> {

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -33,13 +33,11 @@ export interface PeerInfo {
 	readonly wsPort: number;
 }
 
-export interface NodeInfo {
+export interface P2PNodeStatus {
 	readonly wsPort: number;
 	readonly os: string;
 	readonly version: string;
 }
-
-export interface P2PNodeStatus {}
 
 export interface P2PPenalty {}
 

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -14,6 +14,8 @@
  */
 /* tslint:disable:no-empty-interface*/
 
+import { PeerConfig } from './peer';
+
 export interface P2PRequestPacket<T> {
 	readonly procedure: string;
 	readonly params?: T;
@@ -28,30 +30,30 @@ export interface P2PMessagePacket<T> {
 	readonly data: T;
 }
 
-export interface PeerInfo {
-	readonly ipAddress: string;
-	readonly wsPort: number;
-}
-
 export interface P2PNodeStatus {
 	readonly wsPort: number;
 	readonly os: string;
 	readonly version: string;
+	readonly height: number;
 }
 
 export interface P2PPenalty {}
 
 export interface P2PConfig {
-	readonly blacklistedPeers: ReadonlyArray<PeerInfo>;
+	readonly blacklistedPeers: ReadonlyArray<PeerConfig>;
 	readonly connectTimeout: number;
 	readonly ipAddress?: string;
-	readonly seedPeers: ReadonlyArray<PeerInfo>;
+	readonly seedPeers: ReadonlyArray<PeerConfig>;
 	readonly wsEngine?: string;
 	readonly wsPort: number;
 	readonly version: string;
 }
 
-export interface RPCResponsePeerInfo {
+export interface NetworkStatus {}
+
+// This is a representation of the peer object according to the current protocol.
+// TODO later: Switch to LIP protocol format.
+export interface ProtocolPeerInfo {
 	readonly ip: string;
 	readonly wsPort: number;
 	readonly os: string;
@@ -61,8 +63,9 @@ export interface RPCResponsePeerInfo {
 	readonly nonce: string;
 }
 
-export interface RPCResponsePeerList {
+// This is a representation of the peer list according to the current protocol.
+// TODO later: Switch to LIP protocol format.
+export interface ProtocolPeerList {
 	readonly success: boolean;
-	readonly peers: ReadonlyArray<RPCResponsePeerInfo>;
+	readonly peers: ReadonlyArray<ProtocolPeerInfo>;
 }
-export interface NetworkStatus {}

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -13,28 +13,56 @@
  *
  */
 /* tslint:disable:no-empty-interface*/
-export interface P2PMessagePacket {}
 
-export interface P2PRequestPacket {}
+export interface P2PRequestPacket<T> {
+	readonly procedure: string;
+	readonly params?: T;
+}
 
-export interface P2PResponsePacket {}
+export interface P2PResponsePacket {
+	readonly data: unknown;
+}
 
-export interface P2PNodeStatus {}
+export interface P2PMessagePacket<T> {
+	readonly event: string;
+	readonly data: T;
+}
+
+export interface PeerInfo {
+	readonly ipAddress: string;
+	readonly wsPort: number;
+}
+
+export interface NodeInfo {
+	readonly wsPort: number;
+	readonly os: string;
+	readonly version: string;
+}
 
 export interface P2PPenality {}
 
 export interface P2PConfig {
-	readonly blacklistedPeers: ReadonlyArray<string>;
+	readonly blacklistedPeers: ReadonlyArray<PeerInfo>;
 	readonly connectTimeout: number;
 	readonly ipAddress?: string;
-	readonly seedPeers: ReadonlyArray<string>;
+	readonly seedPeers: ReadonlyArray<PeerInfo>;
 	readonly wsEngine?: string;
 	readonly wsPort: number;
+	readonly version: string;
 }
 
-export enum PeerState {
-	BANNED = 0,
-	DISCONNECTED = 1,
-	CONNECTED = 2,
+export interface RPCResponsePeerInfo {
+	readonly ip: string;
+	readonly wsPort: number;
+	readonly os: string;
+	readonly version: string;
+	readonly broadhash: string;
+	readonly height: number;
+	readonly nonce: string;
+}
+
+export interface RPCResponsePeerList {
+	readonly success: boolean;
+	readonly peers: ReadonlyArray<RPCResponsePeerInfo>;
 }
 export interface NetworkStatus {}

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -39,7 +39,9 @@ export interface NodeInfo {
 	readonly version: string;
 }
 
-export interface P2PPenality {}
+export interface P2PNodeStatus {}
+
+export interface P2PPenalty {}
 
 export interface P2PConfig {
 	readonly blacklistedPeers: ReadonlyArray<PeerInfo>;

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -60,7 +60,7 @@ export class Peer {
 		this._wsPort = peerConfig.wsPort;
 		this._id = Peer.constructPeerId(this._ipAddress, this._wsPort);
 		this._inboundSocket = peerConfig.inboundSocket;
-		this._height = peerConfig.height === undefined ? 0 : peerConfig.height;
+		this._height = peerConfig.height ? peerConfig.height : 0;
 	}
 
 	private _createOutboundSocket(): any {

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -84,7 +84,6 @@ export class Peer {
 				resolve: (result: P2PResponsePacket) => void,
 				reject: (result: Error) => void,
 			): void => {
-				// TODO LATER: Change to LIP protocol format.
 				this._outboundSocket.emit(
 					'rpc-request',
 					{
@@ -116,7 +115,6 @@ export class Peer {
 	}
 
 	public send<T>(packet: P2PMessagePacket<T>): void {
-		// TODO LATER: Change to LIP protocol format.
 		this._outboundSocket.emit(packet.event, {
 			data: packet.data,
 		});

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -72,8 +72,13 @@ export class Peer {
 		});
 	}
 
-	public disconnect(): void {
-		return;
+	public disconnect(code: number = 1000, reason?: string): void {
+		if (this._inboundSocket) {
+			this._inboundSocket.disconnect(code, reason);
+		}
+		if (this._outboundSocket) {
+			this._outboundSocket.disconnect(code, reason);
+		}
 	}
 
 	public async request<T>(

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -146,7 +146,7 @@ export class Peer {
 	 * This is not a declared as a setter because this method will need
 	 * invoke an async RPC on the socket to pass it the new node status.
 	 */
-	public updateNodeStatus(value: P2PNodeStatus | undefined): void {
+	public applyNodeStatus(value: P2PNodeStatus | undefined): void {
 		this._nodeStatus = value;
 	}
 

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -12,15 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-/* tslint:disable:interface-name variable-name */
-import { PeerState } from './p2p_types';
+/* tslint:disable:interface-name */
+import {
+	P2PRequestPacket,
+	P2PMessagePacket,
+	P2PResponsePacket,
+	NodeInfo,
+} from './p2p_types';
 
-// TODO: Use to create outbound socket connection inside peer object.
-// TODO: const socketClusterClient = require('socketcluster-client');
+import socketClusterClient from 'socketcluster-client';
 
 export interface PeerConfig {
 	readonly clock?: Date;
-	readonly height: number;
+	readonly height?: number;
 	readonly id: string;
 	/* tslint:disable:next-line: no-any */
 	readonly inboundSocket?: any; // TODO: Type SCServerSocket
@@ -28,41 +32,145 @@ export interface PeerConfig {
 	readonly os?: string;
 	readonly version?: string;
 	readonly wsPort: number;
+	readonly nodeInfo: NodeInfo;
+}
+
+export enum ConnectionState {
+	CONNECTING = 0,
+	CONNECTED = 1,
+	DISCONNECTED = 2,
+}
+
+export interface PeerState {
+	readonly inbound: ConnectionState;
+	readonly outbound: ConnectionState;
+}
+
+interface RawResponseBody {
+	readonly data: unknown;
 }
 
 export class Peer {
 	private readonly _height: number;
 	private readonly _id: string;
-	private readonly _inboundSocket: any;
+	private _inboundSocket: any;
+	private _outboundSocket: any;
 	private readonly _ipAddress: string;
 	private readonly _wsPort: number;
+	private readonly _nodeInfo: NodeInfo;
 
 	public constructor(peerConfig: PeerConfig) {
 		this._id = peerConfig.id;
 		this._ipAddress = peerConfig.ipAddress;
 		this._wsPort = peerConfig.wsPort;
 		this._inboundSocket = peerConfig.inboundSocket;
-		this._height = peerConfig.height;
-	}
-	// TODO: Return BANNED when appropriate.
-	public get state(): PeerState {
-		if (this._inboundSocket.state === this._inboundSocket.OPEN) {
-			return PeerState.CONNECTED;
-		}
-
-		return PeerState.DISCONNECTED;
+		this._nodeInfo = peerConfig.nodeInfo;
+		this._height = peerConfig.height === undefined ? 0 : peerConfig.height;
 	}
 
-	public get height(): number {
-		return this._height;
+	public connect(): void {
+		const nodeInfo = this._nodeInfo;
+		this._outboundSocket = socketClusterClient.create({
+			hostname: this._ipAddress,
+			port: this._wsPort,
+			query: {
+				wsPort: nodeInfo.wsPort,
+				os: nodeInfo.os,
+				version: nodeInfo.version, // TODO LATER: Provide nonce for compatibility with current protocol.
+			},
+		});
+	}
+
+	public disconnect(): void {
+		return;
+	}
+
+	public async request<T>(
+		packet: P2PRequestPacket<T>,
+	): Promise<P2PResponsePacket> {
+		return new Promise<P2PResponsePacket>(
+			(resolve: (result: any) => void, reject: (result: any) => void): void => {
+				// TODO LATER: Change to LIP protocol format.
+				this._outboundSocket.emit(
+					'rpc-request',
+					{
+						type: '/RPCRequest',
+						procedure: packet.procedure,
+						data: packet.params,
+					},
+					(err: Error | undefined, responseData: unknown) => {
+						if (err) {
+							reject(err);
+
+							return;
+						}
+
+						if (responseData) {
+							const rawResponse = responseData as RawResponseBody;
+							resolve({
+								data: rawResponse.data,
+							});
+
+							return;
+						}
+
+						// TODO ASAP: Create new Error type in errors/ directory.
+						const error = new Error('RPC response format was invalid');
+						error.name = 'InvalidPeerResponseError';
+						reject(error);
+					},
+				);
+			},
+		);
+	}
+
+	public send<T>(packet: P2PMessagePacket<T>): void {
+		// TODO LATER: Change to LIP protocol format.
+		this._outboundSocket.emit(packet.event, {
+			data: packet.data,
+		});
 	}
 
 	public get id(): string {
 		return this._id;
 	}
 
+	public set inboundSocket(value: any) {
+		this._inboundSocket = value;
+	}
+
 	public get inboundSocket(): any {
 		return this._inboundSocket;
+	}
+
+	public set outboundSocket(value: any) {
+		this._outboundSocket = value;
+	}
+
+	public get outboundSocket(): any {
+		return this._outboundSocket;
+	}
+
+	public get height(): number {
+		return this._height;
+	}
+
+	public get state(): PeerState {
+		const inbound = this._inboundSocket
+			? this._inboundSocket.state === this._inboundSocket.OPEN
+				? ConnectionState.CONNECTED
+				: ConnectionState.DISCONNECTED
+			: ConnectionState.DISCONNECTED;
+		const outbound = this._outboundSocket
+			? this._outboundSocket.state === this._outboundSocket.OPEN
+				? ConnectionState.CONNECTED
+				: ConnectionState.DISCONNECTED
+			: ConnectionState.DISCONNECTED;
+
+		return {
+			inbound,
+			outbound,
+		};
 	}
 
 	public get ipAddress(): string {

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -14,107 +14,47 @@
  */
 
 /**
- * The purpose of the PeerPool
+ * The purpose of the PeerPool is to provide a simple interface for selecting,
+ * interacting with and handling aggregated events from a collection of peers.
  */
 /* tslint:disable:variable-name */
 import { EventEmitter } from 'events';
-import http, { Server } from 'http';
-import querystring from 'querystring';
-import socketClusterServer from 'socketcluster-server';
-import { PeerTransportError } from './errors';
 import { Peer } from './peer';
 
-export const EVENT_INBOUND_PEER_FAIL = 'inboundPeerFail';
-export const EVENT_NEW_INBOUND_PEER = 'newInboundPeer';
-export const EVENT_NEW_PEER = 'newPeer';
-
-export interface PeerPoolConfig {
-	readonly blacklistedPeers?: ReadonlyArray<string>;
-	readonly connectTimeout: number;
-	readonly ipAddress?: string;
-	readonly seedPeers: ReadonlyArray<string>;
-	readonly wsEngine?: string;
-	readonly wsPort: number;
-}
-
 export class PeerPool extends EventEmitter {
-	private readonly _config: PeerPoolConfig;
-	private readonly _httpServer: Server;
-	private readonly _newPeers: Map<string, Peer>;
-	/* tslint:disable:next-line: no-any */
-	private readonly _scServer: any;
-	private readonly _triedPeers: Map<string, Peer>;
+	private readonly _peerMap: Map<string, Peer>;
 
-	public constructor(config: PeerPoolConfig) {
+	public constructor() {
 		super();
-
-		this._config = config;
-		this._httpServer = http.createServer();
-		this._newPeers = new Map();
-		this._scServer = socketClusterServer.attach(this._httpServer);
-		this._triedPeers = new Map();
-
-		this._handleInboundConnections(this._scServer);
+		this._peerMap = new Map();
 	}
 
-	public get newPeers(): ReadonlyArray<Peer> {
-		return Array.from(this._newPeers.values());
+	// TODO ASAP: Implement. Use PeerOptions type instead of any for selectionParams.
+	public selectPeers(
+		selectionParams: any,
+		numOfPeers: number,
+	): ReadonlyArray<Peer> {
+		selectionParams;
+		numOfPeers;
+
+		return [];
 	}
 
-	public get triedPeers(): ReadonlyArray<Peer> {
-		return Array.from(this._triedPeers.values());
+	public hasPeer(peerId: string): boolean {
+		return this._peerMap.has(peerId);
 	}
 
-	// TODO: Connect to seed nodes and start discovery process.
-	public async start(): Promise<void> {
-		/* tslint:disable:next-line: no-unused-expression */
-		this._config; // TODO: Connect to seed nodes from this._config
-
-		return Promise.resolve();
+	public addPeer(peer: Peer): void {
+		this._peerMap.set(peer.id, peer);
 	}
 
-	// TODO
-	/* tslint:disable:next-line: prefer-function-over-method */
-	public async stop(): Promise<void> {
-		return Promise.resolve();
+	public getPeer(peerId: string): Peer | undefined {
+		return this._peerMap.get(peerId);
 	}
 
-	private _addInboundPeerToMaps(peer: Peer): void {
-		const peerId: string = peer.id;
-
-		if (this._triedPeers.has(peerId)) {
-			const error: PeerTransportError = new PeerTransportError(
-				`Received inbound connection from peer ${peerId} which is already in our triedPeers map.`,
-				peerId,
-			);
-			this.emit(EVENT_INBOUND_PEER_FAIL, error);
-		} else if (this._newPeers.has(peerId)) {
-			const error: PeerTransportError = new PeerTransportError(
-				`Received inbound connection from peer ${peerId} which is already in our newPeers map.`,
-				peerId,
-			);
-			this.emit(EVENT_INBOUND_PEER_FAIL, error);
-		} else {
-			this._newPeers.set(peerId, peer);
-			super.emit(EVENT_NEW_INBOUND_PEER, peer);
-			super.emit(EVENT_NEW_PEER, peer);
-		}
-	}
-
-	private _handleInboundConnections(scServer: any): void {
-		scServer.on('connection', (socket: any) => {
-			const queryObject: any = querystring.parse(socket.request.url);
-			const peer: Peer = new Peer({
-				clock: new Date(),
-				height: 0,
-				id: `${socket.remoteAddress}:${queryObject.wsPort}`,
-				inboundSocket: socket,
-				ipAddress: socket.remoteAddress,
-				os: queryObject.os,
-				version: queryObject.version,
-				wsPort: queryObject.wsPort,
-			});
-			this._addInboundPeerToMaps(peer);
+	public disconnectAllPeers(): void {
+		this._peerMap.forEach((peer: Peer) => {
+			peer.disconnect();
 		});
 	}
 }

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -17,7 +17,7 @@
  * The purpose of the PeerPool is to provide a simple interface for selecting,
  * interacting with and handling aggregated events from a collection of peers.
  */
-/* tslint:disable:variable-name */
+
 import { EventEmitter } from 'events';
 import { Peer } from './peer';
 
@@ -46,6 +46,10 @@ export class PeerPool extends EventEmitter {
 
 	public addPeer(peer: Peer): void {
 		this._peerMap.set(peer.id, peer);
+	}
+
+	public removePeer(peerId: string): boolean {
+		return this._peerMap.delete(peerId);
 	}
 
 	public getPeer(peerId: string): Peer | undefined {

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -2,7 +2,7 @@ import { P2P } from '../../src/index';
 
 describe('Integration tests for P2P library', () => {
 	const NETWORK_PEER_COUNT = 10;
-	let blockchainP2PList: Array<P2P> = [];
+	let blockchainP2PList: ReadonlyArray<P2P> = [];
 
 	describe('Start and stop network', () => {
 		beforeEach(async () => {
@@ -13,14 +13,15 @@ describe('Integration tests for P2P library', () => {
 					seedPeers: [],
 					wsEngine: 'ws',
 					wsPort: 5000 + index,
+					version: '1.0.0',
 				});
 			});
 
-			let peerStartPromises: Array<Promise<void>> = blockchainP2PList.map(
-				blockchainP2P => {
-					return blockchainP2P.start();
-				},
-			);
+			let peerStartPromises: ReadonlyArray<
+				Promise<void>
+			> = blockchainP2PList.map(blockchainP2P => {
+				return blockchainP2P.start();
+			});
 			await Promise.all(peerStartPromises);
 		});
 


### PR DESCRIPTION
### What was the problem?

P2P node needs to be able start, connect to seed peers and initiate discovery.
As part of this, basic peer management functionality is required.

### How did I fix it?

Implemented:

- Basic node start functionality.
- Basic peer management.
- Initiate peer discovery through seed nodes.
- Basic peer connection.
- Peer request() and send() methods.
- Cleanup of existing code.

### How to test it?

`npm test`

### Review checklist

* The PR partially resolves #894 and #895 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
